### PR TITLE
Add has_labels flag to Message to speed up admin views

### DIFF
--- a/casepro/msgs/migrations/0027_message_has_labels.py
+++ b/casepro/msgs/migrations/0027_message_has_labels.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def populate_has_labels(apps, schema_editor):
+    Org = apps.get_model('orgs', 'Org')
+
+    for org in Org.objects.order_by('pk'):
+        print "Updating labels for org #%d..." % org.pk
+
+        for label in org.labels.all():
+            print " > Updating messages for label %s..." % label.name
+            label.messages.update(has_labels=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0026_auto_20160309_1337'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='message',
+            name='has_labels',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(populate_has_labels)
+    ]

--- a/casepro/msgs/migrations/0028_message_triggers.py
+++ b/casepro/msgs/migrations/0028_message_triggers.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+TRIGGER_SQL = """
+----------------------------------------------------------------------
+-- Trigger procedure to maintain message.has_labels
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION msgs_message_labels_on_change() RETURNS TRIGGER AS $$
+DECLARE
+  _label_id INT;
+BEGIN
+  -- label applied to message
+  IF TG_OP = 'INSERT' THEN
+    UPDATE msgs_message SET has_labels = TRUE WHERE id = NEW.message_id AND has_labels = FALSE;
+
+  -- label removed from message
+  ELSIF TG_OP = 'DELETE' THEN
+    -- are there any remaining labels on this message?
+    SELECT label_id INTO _label_id FROM msgs_message_labels WHERE message_id = OLD.message_id LIMIT 1;
+
+    IF NOT FOUND THEN
+      UPDATE msgs_message SET has_labels = FALSE WHERE id = OLD.message_id;
+    END IF;
+
+  -- no more labels for any messages
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    UPDATE msgs_message SET has_labels = 0;
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT and DELETE on msgs_msg_labels
+DROP TRIGGER IF EXISTS msgs_message_labels_on_change_trg ON msgs_message_labels;
+CREATE TRIGGER msgs_message_labels_on_change_trg
+   AFTER INSERT OR DELETE ON msgs_message_labels
+   FOR EACH ROW EXECUTE PROCEDURE msgs_message_labels_on_change();
+
+-- install for TRUNCATE on msgs_msg_labels
+DROP TRIGGER IF EXISTS msgs_message_labels_on_truncate_trg ON msgs_message_labels;
+CREATE TRIGGER msgs_message_labels_on_truncate_trg
+  AFTER TRUNCATE ON msgs_message_labels
+  EXECUTE PROCEDURE msgs_message_labels_on_change();
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0027_message_has_labels'),
+    ]
+
+    operations = [
+        migrations.RunSQL(TRIGGER_SQL)
+    ]

--- a/casepro/msgs/migrations/0028_message_triggers.py
+++ b/casepro/msgs/migrations/0028_message_triggers.py
@@ -2,51 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-
-
-TRIGGER_SQL = """
-----------------------------------------------------------------------
--- Trigger procedure to maintain message.has_labels
-----------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION msgs_message_labels_on_change() RETURNS TRIGGER AS $$
-DECLARE
-  _label_id INT;
-BEGIN
-  -- label applied to message
-  IF TG_OP = 'INSERT' THEN
-    UPDATE msgs_message SET has_labels = TRUE WHERE id = NEW.message_id AND has_labels = FALSE;
-
-  -- label removed from message
-  ELSIF TG_OP = 'DELETE' THEN
-    -- are there any remaining labels on this message?
-    SELECT label_id INTO _label_id FROM msgs_message_labels WHERE message_id = OLD.message_id LIMIT 1;
-
-    IF NOT FOUND THEN
-      UPDATE msgs_message SET has_labels = FALSE WHERE id = OLD.message_id;
-    END IF;
-
-  -- no more labels for any messages
-  ELSIF TG_OP = 'TRUNCATE' THEN
-    UPDATE msgs_message SET has_labels = 0;
-
-  END IF;
-
-  RETURN NULL;
-END;
-$$ LANGUAGE plpgsql;
-
--- install for INSERT and DELETE on msgs_msg_labels
-DROP TRIGGER IF EXISTS msgs_message_labels_on_change_trg ON msgs_message_labels;
-CREATE TRIGGER msgs_message_labels_on_change_trg
-   AFTER INSERT OR DELETE ON msgs_message_labels
-   FOR EACH ROW EXECUTE PROCEDURE msgs_message_labels_on_change();
-
--- install for TRUNCATE on msgs_msg_labels
-DROP TRIGGER IF EXISTS msgs_message_labels_on_truncate_trg ON msgs_message_labels;
-CREATE TRIGGER msgs_message_labels_on_truncate_trg
-  AFTER TRUNCATE ON msgs_message_labels
-  EXECUTE PROCEDURE msgs_message_labels_on_change();
-"""
+from casepro.sql import InstallSQL
 
 
 class Migration(migrations.Migration):
@@ -56,5 +12,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL(TRIGGER_SQL)
+        InstallSQL('msgs_0001')
     ]

--- a/casepro/msgs/migrations/0029_folder_indexes_pt3.py
+++ b/casepro/msgs/migrations/0029_folder_indexes_pt3.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+INDEX_SQL = """
+DROP INDEX msgs_inbox;
+CREATE INDEX msgs_inbox
+ON msgs_message(org_id, created_on DESC)
+WHERE is_active = TRUE AND is_handled = TRUE AND is_archived = FALSE AND has_labels = TRUE;
+
+DROP INDEX msgs_unlabelled_inbox;
+CREATE INDEX msgs_unlabelled_inbox
+ON msgs_message(org_id, created_on DESC)
+WHERE is_active = TRUE AND is_handled = TRUE AND is_archived = FALSE AND "type" = 'I' AND has_labels = FALSE;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0028_message_triggers'),
+    ]
+
+    operations = [
+        migrations.RunSQL(INDEX_SQL)
+    ]

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -165,54 +165,68 @@ class Message(models.Model):
         """
         Search for messages
         """
-        labels = Label.get_all(org, user)
+        folder = search.get('folder')
+        label_id = search.get('label')
+        include_archived = search.get('include_archived')
+        text = search.get('text')
+        contact_uuid = search.get('contact')
+        group_uuids = search.get('groups')
+        after = search.get('after')
+        before = search.get('before')
 
         # only show non-deleted handled messages
         queryset = org.incoming_messages.filter(is_active=True, is_handled=True)
+        all_label_access = user.can_administer(org)
 
-        # filter by user labels.. or exclude them for the unlabelled view
-        if search['folder'] == MessageFolder.unlabelled:
-            queryset = queryset.filter(type=Message.TYPE_INBOX)
-
-            # TODO need a trigger based has_labels flag on Message to speed up this view and the inbox view for admins
-            # For now we just return all messages, and let angular remove the labelled ones
-
-            # queryset = queryset.exclude(labels__in=labels)  # too slow...
-            pass
+        if all_label_access:
+            if folder == MessageFolder.inbox:
+                if label_id:
+                    label = Label.get_all(org, user).filter(pk=label_id).first()
+                    queryset = queryset.filter(labels=label)
+                else:
+                    queryset = queryset.filter(has_labels=True)
+            elif folder == MessageFolder.unlabelled:
+                # only show inbox messages in unlabelled
+                queryset = queryset.filter(type=Message.TYPE_INBOX, has_labels=False)
         else:
-            if search['label']:
-                labels = labels.filter(pk=search['label'])
+            labels = Label.get_all(org, user)
+
+            if label_id:
+                labels = labels.filter(pk=label_id)
             else:
                 # if not filtering by a single label, need distinct to avoid duplicates
                 queryset = queryset.distinct()
 
-            queryset = queryset.filter(labels__in=list(labels))
+            queryset = queryset.filter(has_labels=True, labels__in=list(labels))
+
+            if folder == MessageFolder.unlabelled:
+                raise ValueError("Unlabelled folder is only accessible to administrators")
+
+        # only show flagged messages in flagged folder
+        if folder == MessageFolder.flagged:
+            queryset = queryset.filter(is_flagged=True)
 
         # archived messages can be implicitly or explicitly included depending on folder
-        if search['folder'] == MessageFolder.archived:
+        if folder == MessageFolder.archived:
             queryset = queryset.filter(is_archived=True)
-        elif search['folder'] == MessageFolder.flagged:
-            if not search['include_archived']:
+        elif folder == MessageFolder.flagged:
+            if not include_archived:
                 queryset = queryset.filter(is_archived=False)
         else:
             queryset = queryset.filter(is_archived=False)
 
-        # only show flagged messages in flagged folder
-        if search['folder'] == MessageFolder.flagged:
-            queryset = queryset.filter(is_flagged=True)
+        if text:
+            queryset = queryset.filter(text__icontains=text)
 
-        if search['text']:
-            queryset = queryset.filter(text__icontains=search['text'])
+        if contact_uuid:
+            queryset = queryset.filter(contact__uuid=contact_uuid)
+        if group_uuids:
+            queryset = queryset.filter(contact__groups__uuid__in=group_uuids).distinct()
 
-        if search['contact']:
-            queryset = queryset.filter(contact__uuid=search['contact'])
-        if search['groups']:
-            queryset = queryset.filter(contact__groups__uuid__in=search['groups']).distinct()
-
-        if search['after']:
-            queryset = queryset.filter(created_on__gt=search['after'])
-        if search['before']:
-            queryset = queryset.filter(created_on__lt=search['before'])
+        if after:
+            queryset = queryset.filter(created_on__gt=after)
+        if before:
+            queryset = queryset.filter(created_on__lt=before)
 
         queryset = queryset.select_related('contact').prefetch_related('labels', 'case__assignee')
 

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -130,6 +130,8 @@ class Message(models.Model):
 
     labels = models.ManyToManyField(Label, help_text=_("Labels assigned to this message"), related_name='messages')
 
+    has_labels = models.BooleanField(default=False)  # maintained via db triggers
+
     is_flagged = models.BooleanField(default=False)
 
     is_archived = models.BooleanField(default=False)

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -200,6 +200,30 @@ class MessageTest(BaseCasesTest):
         self.msg4 = self.create_message(self.unicef, 104, self.ann, "Flagged", is_flagged=True)
         self.msg5 = self.create_message(self.unicef, 105, self.ann, "Inactive", is_active=False)
 
+    def test_triggers(self):
+        msg = self.create_message(self.unicef, 101, self.ann, "Normal")
+        self.assertFalse(msg.has_labels)
+
+        msg.labels.add(self.aids)
+        msg.refresh_from_db()
+        self.assertTrue(msg.has_labels)
+
+        msg.labels.add(self.pregnancy)
+        msg.refresh_from_db()
+        self.assertTrue(msg.has_labels)
+
+        msg.labels.remove(self.aids)
+        msg.refresh_from_db()
+        self.assertTrue(msg.has_labels)
+
+        msg.labels.remove(self.pregnancy)
+        msg.refresh_from_db()
+        self.assertFalse(msg.has_labels)
+
+        msg.labels.add(self.aids, self.pregnancy)  # add multiple
+        msg.refresh_from_db()
+        self.assertTrue(msg.has_labels)
+
     def test_save(self):
         # start with no labels or contacts
         Label.objects.all().delete()

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -277,7 +277,7 @@ class MessageTest(BaseCasesTest):
         self.assertEqual(set(message.labels.all()), {feedback, important})
 
     def test_search(self):
-        eric = self.create_contact(self.nyaruka, 'C-101', "Nic")
+        eric = self.create_contact(self.nyaruka, 'C-101', "Eric")
 
         # unlabelled
         msg1 = self.create_message(self.unicef, 101, self.ann, "Hello 1", is_handled=True)

--- a/casepro/sql/__init__.py
+++ b/casepro/sql/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+import os
+
+from django.db.migrations import RunSQL
+
+
+class InstallSQL(RunSQL):
+    """
+    Migration that reads the SQL from the named file and runs it as a RunSQL migration
+    """
+    def __init__(self, filename):
+        # build the full path to our filename
+        sql_path = os.path.join(os.path.dirname(__file__), '%s.sql' % filename)
+        with open(sql_path) as sql_file:
+            sql = sql_file.read()
+
+        super(InstallSQL, self).__init__(sql)

--- a/casepro/sql/msgs_0001.sql
+++ b/casepro/sql/msgs_0001.sql
@@ -1,0 +1,41 @@
+----------------------------------------------------------------------
+-- Trigger procedure to maintain message.has_labels
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION msgs_message_labels_on_change() RETURNS TRIGGER AS $$
+DECLARE
+  _label_id INT;
+BEGIN
+  -- label applied to message
+  IF TG_OP = 'INSERT' THEN
+    UPDATE msgs_message SET has_labels = TRUE WHERE id = NEW.message_id AND has_labels = FALSE;
+
+  -- label removed from message
+  ELSIF TG_OP = 'DELETE' THEN
+    -- are there any remaining labels on this message?
+    SELECT label_id INTO _label_id FROM msgs_message_labels WHERE message_id = OLD.message_id LIMIT 1;
+
+    IF NOT FOUND THEN
+      UPDATE msgs_message SET has_labels = FALSE WHERE id = OLD.message_id;
+    END IF;
+
+  -- no more labels for any messages
+  ELSIF TG_OP = 'TRUNCATE' THEN
+    UPDATE msgs_message SET has_labels = 0;
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- install for INSERT and DELETE on msgs_msg_labels
+DROP TRIGGER IF EXISTS msgs_message_labels_on_change_trg ON msgs_message_labels;
+CREATE TRIGGER msgs_message_labels_on_change_trg
+   AFTER INSERT OR DELETE ON msgs_message_labels
+   FOR EACH ROW EXECUTE PROCEDURE msgs_message_labels_on_change();
+
+-- install for TRUNCATE on msgs_msg_labels
+DROP TRIGGER IF EXISTS msgs_message_labels_on_truncate_trg ON msgs_message_labels;
+CREATE TRIGGER msgs_message_labels_on_truncate_trg
+  AFTER TRUNCATE ON msgs_message_labels
+  EXECUTE PROCEDURE msgs_message_labels_on_change();


### PR DESCRIPTION
Admins see messages with all labels for their org but filtering over all labels to determine if a message belongs in the Inbox (i.e. it's labelled) or the Unlabelled folder, is slow. This adds a `has_labels` field which is maintained by a db trigger.