### PR TITLE
Dynamic group support

### DIFF
--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -101,10 +101,13 @@ class GroupSyncer(BaseSyncer):
             'uuid': remote.uuid,
             'name': remote.name,
             'count': remote.count,
+            'is_dynamic': remote.query is not None
         }
 
     def update_required(self, local, remote, remote_as_kwargs):
-        return local.name != remote.name or local.count != remote.count
+        return local.name != remote.name \
+               or local.count != remote.count \
+               or local.is_dynamic != remote_as_kwargs['is_dynamic']
 
 
 class LabelSyncer(BaseSyncer):

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -359,8 +359,8 @@ class RapidProBackendTest(BaseCasesTest):
         Group.objects.all().delete()
 
         mock_get_groups.return_value = MockClientQuery([
-            TembaGroup.create(uuid="G-001", name="Customers", count=45),
-            TembaGroup.create(uuid="G-002", name="Developers", count=32),
+            TembaGroup.create(uuid="G-001", name="Customers", query=None, count=45),
+            TembaGroup.create(uuid="G-002", name="Developers", query="isdev=yes", count=32),
         ])
 
         with self.assertNumQueries(5):
@@ -368,12 +368,12 @@ class RapidProBackendTest(BaseCasesTest):
 
         self.assertEqual((num_created, num_updated, num_deleted, num_ignored), (2, 0, 0, 0))
 
-        Group.objects.get(uuid="G-001", name="Customers", count=45, is_active=True)
-        Group.objects.get(uuid="G-002", name="Developers", count=32, is_active=True)
+        Group.objects.get(uuid="G-001", name="Customers", count=45, is_dynamic=False, is_active=True)
+        Group.objects.get(uuid="G-002", name="Developers", count=32, is_dynamic=True, is_active=True)
 
         mock_get_groups.return_value = MockClientQuery([
-            TembaGroup.create(uuid="G-002", name="Devs", count=32),
-            TembaGroup.create(uuid="G-003", name="Spammers", count=13),
+            TembaGroup.create(uuid="G-002", name="Devs", query="isdev=yes", count=32),
+            TembaGroup.create(uuid="G-003", name="Spammers", query=None, count=13),
         ])
 
         with self.assertNumQueries(6):
@@ -381,9 +381,9 @@ class RapidProBackendTest(BaseCasesTest):
 
         self.assertEqual((num_created, num_updated, num_deleted, num_ignored), (1, 1, 1, 0))
 
-        Group.objects.get(uuid="G-001", name="Customers", count=45, is_active=False)
-        Group.objects.get(uuid="G-002", name="Devs", count=32, is_active=True)
-        Group.objects.get(uuid="G-003", name="Spammers", count=13, is_active=True)
+        Group.objects.get(uuid="G-001", name="Customers", count=45, is_dynamic=False, is_active=False)
+        Group.objects.get(uuid="G-002", name="Devs", count=32, is_dynamic=True, is_active=True)
+        Group.objects.get(uuid="G-003", name="Spammers", count=13, is_dynamic=False, is_active=True)
 
         # check that no changes means no updates
         with self.assertNumQueries(3):

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -148,7 +148,8 @@ class CaseTest(BaseCasesTest):
         self.assertEqual(actions[2].created_on, d3)
 
         # check that contacts groups were restored
-        self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).groups.all()), {self.females, self.reporters, self.registered})
+        self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).groups.all()),
+                         {self.females, self.reporters, self.registered})
         self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).suspended_groups.all()), set())
 
         mock_add_to_group.assert_called_once_with(self.unicef, self.ann, self.reporters)

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -31,7 +31,7 @@ class CaseTest(BaseCasesTest):
 
         self.ann = self.create_contact(self.unicef, 'C-001', "Ann",
                                        fields={'age': "34"},
-                                       groups=[self.females, self.reporters])
+                                       groups=[self.females, self.reporters, self.registered])
 
     @patch('casepro.test.TestBackend.archive_contact_messages')
     @patch('casepro.test.TestBackend.archive_messages')
@@ -89,7 +89,7 @@ class CaseTest(BaseCasesTest):
         mock_remove_from_group.reset_mock()
 
         # check that contacts groups were suspended
-        self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).groups.all()), {self.females})
+        self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).groups.all()), {self.females, self.registered})
         self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).suspended_groups.all()), {self.reporters})
 
         # check that contact's runs were expired
@@ -148,7 +148,7 @@ class CaseTest(BaseCasesTest):
         self.assertEqual(actions[2].created_on, d3)
 
         # check that contacts groups were restored
-        self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).groups.all()), {self.females, self.reporters})
+        self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).groups.all()), {self.females, self.reporters, self.registered})
         self.assertEqual(set(Contact.objects.get(pk=self.ann.pk).suspended_groups.all()), set())
 
         mock_add_to_group.assert_called_once_with(self.unicef, self.ann, self.reporters)

--- a/casepro/contacts/migrations/0019_group_is_dynamic.py
+++ b/casepro/contacts/migrations/0019_group_is_dynamic.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0018_contact_is_blocked'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='group',
+            name='is_dynamic',
+            field=models.BooleanField(default=False, help_text='Whether this group is dynamic'),
+        ),
+    ]

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -122,6 +122,28 @@ class ContactCRUDLTest(BaseCasesTest):
         self.assertContains(response, "age=32")
 
 
+class GroupTest(BaseCasesTest):
+    def test_model(self):
+        invisible = self.create_group(self.unicef, "G-006", "Invisible", count=12, is_visible=False)
+
+        self.assertEqual(set(Group.get_all(self.unicef)),
+                         {self.males, self.females, self.reporters, self.registered, invisible})
+
+        self.assertEqual(set(Group.get_all(self.unicef, visible=True)),
+                         {self.males, self.females, self.reporters, self.registered})
+
+        self.assertEqual(set(Group.get_all(self.unicef, dynamic=False)),
+                         {self.males, self.females, self.reporters, invisible})
+
+        self.assertEqual(invisible.as_json(), {
+            'id': invisible.pk,
+            'uuid': "G-006",
+            'name': "Invisible",
+            'count': 12,
+            'is_dynamic': False
+        })
+
+
 class TasksTest(BaseCasesTest):
     @patch('casepro.test.TestBackend.pull_fields')
     @patch('casepro.test.TestBackend.pull_groups')

--- a/casepro/orgs_ext/forms.py
+++ b/casepro/orgs_ext/forms.py
@@ -4,10 +4,16 @@ from dash.orgs.models import Org
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.utils.translation import ugettext_lazy as _
 from timezones.forms import TimeZoneField
+
+from casepro.contacts.models import Field, Group
 
 
 class OrgForm(forms.ModelForm):
+    """
+    Form for superusers to create and update orgs
+    """
     language = forms.ChoiceField(required=False, choices=[('', '')] + list(settings.LANGUAGES))
     timezone = TimeZoneField()
 
@@ -20,3 +26,49 @@ class OrgForm(forms.ModelForm):
     class Meta:
         model = Org
         fields = forms.ALL_FIELDS
+
+
+class OrgEditForm(forms.ModelForm):
+    """
+    Form for org admins to update their own org
+    """
+    name = forms.CharField(label=_("Organization"),
+                           help_text=_("The name of this organization"))
+
+    timezone = TimeZoneField(help_text=_("The timezone your organization is in"))
+
+    banner_text = forms.CharField(label=_("Banner text"), widget=forms.Textarea,
+                                  help_text=_("Banner text displayed to all users"), required=False)
+
+    contact_fields = forms.MultipleChoiceField(choices=(), label=_("Contact fields"),
+                                               help_text=_("Contact fields to display"), required=False)
+
+    suspend_groups = forms.MultipleChoiceField(
+        choices=(), label=_("Suspend groups"),
+        help_text=_("Groups to remove contacts from when creating cases"),
+        required=False
+    )
+
+    def __init__(self, *args, **kwargs):
+        org = kwargs.pop('org')
+        super(OrgEditForm, self).__init__(*args, **kwargs)
+
+        self.fields['banner_text'].initial = org.get_banner_text()
+
+        field_choices = []
+        for field in Field.objects.filter(org=org, is_active=True).order_by('label'):
+            field_choices.append((field.pk, "%s (%s)" % (field.label, field.key)))
+
+        self.fields['contact_fields'].choices = field_choices
+        self.fields['contact_fields'].initial = [f.pk for f in Field.get_all(org, visible=True)]
+
+        group_choices = []
+        for group in Group.get_all(org, dynamic=False).order_by('name'):
+            group_choices.append((group.pk, group.name))
+
+        self.fields['suspend_groups'].choices = group_choices
+        self.fields['suspend_groups'].initial = [g.pk for g in Group.get_suspend_from(org)]
+
+    class Meta:
+        model = Org
+        fields = ('name', 'timezone', 'banner_text', 'contact_fields', 'suspend_groups', 'logo')

--- a/casepro/orgs_ext/views.py
+++ b/casepro/orgs_ext/views.py
@@ -76,11 +76,11 @@ class OrgExtCRUDL(SmartCRUDL):
                 self.fields['contact_fields'].initial = [f.pk for f in Field.get_all(org, visible=True)]
 
                 group_choices = []
-                for group in Group.get_all(org).order_by('name'):
+                for group in Group.get_all(org, dynamic=False).order_by('name'):
                     group_choices.append((group.pk, group.name))
 
                 self.fields['suspend_groups'].choices = group_choices
-                self.fields['suspend_groups'].initial = [g.pk for g in Group.get_all(org).filter(suspend_from=True)]
+                self.fields['suspend_groups'].initial = [g.pk for g in Group.get_suspend_from(org)]
 
             class Meta:
                 model = Org

--- a/casepro/test.py
+++ b/casepro/test.py
@@ -63,7 +63,8 @@ class BaseCasesTest(DashTest):
         self.males = self.create_group(self.unicef, "G-001", "Males")
         self.females = self.create_group(self.unicef, "G-002", "Females")
         self.reporters = self.create_group(self.unicef, "G-003", "Reporters", suspend_from=True)
-        self.coders = self.create_group(self.nyaruka, "G-004", 'Coders')
+        self.registered = self.create_group(self.unicef, "G-004", "Registered (Dynamic)", is_dynamic=True)
+        self.coders = self.create_group(self.nyaruka, "G-005", 'Coders')
 
         # some fields
         self.nickname = self.create_field(self.unicef, 'nickname', "Nickname", value_type='T')
@@ -92,8 +93,9 @@ class BaseCasesTest(DashTest):
         contact.groups.add(*groups)
         return contact
 
-    def create_group(self, org, uuid, name, is_visible=True, suspend_from=False):
-        return Group.objects.create(org=org, uuid=uuid, name=name, is_visible=is_visible, suspend_from=suspend_from)
+    def create_group(self, org, uuid, name, count=None, is_dynamic=False, is_visible=True, suspend_from=False):
+        return Group.objects.create(org=org, uuid=uuid, name=name, count=count,
+                                    is_dynamic=is_dynamic, is_visible=is_visible, suspend_from=suspend_from)
 
     def create_field(self, org, key, label, value_type='T', is_visible=True):
         return Field.objects.create(org=org, key=key, label=label, value_type=value_type, is_visible=is_visible)

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -38,7 +38,7 @@ psycopg2==2.6.1
 pycountry==1.12
 python-dateutil==2.4.2
 pytz==2015.7
--e git+https://github.com/rapidpro/rapidpro-python.git@78b1738c6f044301e012785623ac8b5f9dd403b0#egg=rapidpro_python-master
+-e git+https://github.com/rapidpro/rapidpro-python.git@a6c71cc4ca2bf4259948f5ce406276c0f5a394d1#egg=rapidpro_python-master
 raven==5.3.1
 redis==2.10.3
 regex==2015.10.01


### PR DESCRIPTION
* adds `is_dynamic` field to `Group`
* prevents trying to suspend contacts from or restore contacts to dynamic groups
* don't list dynamic groups as options for group suspension

Once this has been deployed and groups are re-synced on prod - then can push another change to unmark any dynamic groups as suspend groups.
