### PR TITLE
Outgoing message improvements

### DIFF
--- a/casepro/backend/__init__.py
+++ b/casepro/backend/__init__.py
@@ -84,15 +84,12 @@ class BaseBackend(object):
         """
 
     @abstractmethod
-    def create_outgoing(self, org, text, contacts, urns):
+    def push_outgoing(self, org, outgoing):
         """
-        Creates an outgoing broadcast message
+        Pushes (i.e. sends) an outgoing broadcast message
 
         :param org: the org
-        :param text: the message text
-        :param contacts: the contact recipients
-        :param urns: the raw URN recipients
-        :return: tuple of the broadcast id and it's timestamp
+        :param outgoing: the outgoing message
         """
 
     @abstractmethod

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -253,10 +253,13 @@ class RapidProBackend(BaseBackend):
 
         return remote.uuid
 
-    def create_outgoing(self, org, text, contacts, urns):
+    def push_outgoing(self, org, outgoing):
         client = self._get_client(org, 1)
-        broadcast = client.create_broadcast(text=text, contacts=[c.uuid for c in contacts], urns=urns)
-        return broadcast.id, broadcast.created_on
+        contact_uuids = [c.uuid for c in outgoing.contacts.all()]
+        broadcast = client.create_broadcast(text=outgoing.text, contacts=contact_uuids, urns=list(outgoing.urns))
+
+        outgoing.backend_id = broadcast.id
+        outgoing.save(update_fields=('backend_id',))
 
     def add_to_group(self, org, contact, group):
         client = self._get_client(org, 1)

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -14,7 +14,7 @@ from redis_cache import get_redis_connection
 
 from casepro.backend import get_backend
 from casepro.contacts.models import Contact
-from casepro.msgs.models import Label, Message
+from casepro.msgs.models import Label, Message, Outgoing
 from casepro.utils.export import BaseExport
 
 
@@ -308,6 +308,10 @@ class Case(models.Model):
         self.labels.add(label)
 
         CaseAction.create(self, user, CaseAction.LABEL, label=label)
+
+    @case_action()
+    def reply(self, user, text):
+        return Outgoing.create_case_reply(self.org, user, text, self)
 
     @case_action()
     def unlabel(self, user, label):

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -102,7 +102,7 @@ class case_action(object):
         def wrapped(case, user, *args, **kwargs):
             access = case.access_level(user)
             if (access == AccessLevel.update) or (not self.require_update and access == AccessLevel.read):
-                func(case, user, *args, **kwargs)
+                return func(case, user, *args, **kwargs)
             else:
                 raise PermissionDenied()
         return wrapped

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -235,7 +235,7 @@ class Case(models.Model):
             backend = get_backend()
             backend_messages = backend.fetch_contact_messages(self.org, self.contact, after, before)
 
-            local_by_backend_id = {o.backend_id: o for o in local_outgoing}
+            local_by_backend_id = {o.backend_id: o for o in local_outgoing if o.backend_id}
 
             for msg in backend_messages:
                 # annotate with sender from local message if there is one

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -358,8 +358,8 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(response.status_code, 200)
 
     @patch('casepro.test.TestBackend.fetch_contact_messages')
-    @patch('casepro.test.TestBackend.create_outgoing')
-    def test_timeline(self, mock_create_outgoing, mock_fetch_contact_messages):
+    @patch('casepro.test.TestBackend.push_outgoing')
+    def test_timeline(self, mock_push_outgoing, mock_fetch_contact_messages):
         d0 = datetime(2014, 1, 2, 12, 0, tzinfo=pytz.UTC)
         d1 = datetime(2014, 1, 2, 13, 0, tzinfo=pytz.UTC)
         d2 = datetime(2014, 1, 2, 14, 0, tzinfo=pytz.UTC)
@@ -446,8 +446,9 @@ class CaseCRUDLTest(BaseCasesTest):
 
         # user sends an outgoing message
         d3 = timezone.now()
-        mock_create_outgoing.return_value = (202, d3)
-        Outgoing.create(self.unicef, self.user1, Outgoing.CASE_REPLY, "It's bad", ['C-001'], [], case)
+        outgoing = Outgoing.create_case_reply(self.unicef, self.user1, "It's bad", case)
+        outgoing.backend_id = 202
+        outgoing.save()
 
         # page again looks for new timeline activity
         response = self.url_get('unicef', '%s?after=%s' % (timeline_url, datetime_to_microseconds(t2)))

--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -45,7 +45,7 @@ class CaseSearchMixin(object):
 
 class CaseCRUDL(SmartCRUDL):
     model = Case
-    actions = ('read', 'open', 'update_summary', 'fetch', 'search', 'timeline',
+    actions = ('read', 'open', 'update_summary', 'reply', 'fetch', 'search', 'timeline',
                'note', 'reassign', 'close', 'reopen', 'label')
 
     class Read(OrgObjPermsMixin, SmartReadView):
@@ -177,6 +177,17 @@ class CaseCRUDL(SmartCRUDL):
             summary = request.POST['summary']
             case.update_summary(request.user, summary)
             return HttpResponse(status=204)
+
+    class Reply(OrgObjPermsMixin, SmartUpdateView):
+        """
+        JSON endpoint for replying in a case
+        """
+        permission = 'cases.case_update'
+
+        def post(self, request, *args, **kwargs):
+            case = self.get_object()
+            outgoing = case.reply(request.user, request.POST['text'])
+            return JsonResponse({'id': outgoing.pk})
 
     class Fetch(OrgPermsMixin, SmartReadView):
         """

--- a/casepro/msgs/migrations/0034_auto_20160512_1200.py
+++ b/casepro/msgs/migrations/0034_auto_20160512_1200.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.contrib.postgres.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0020_unset_suspend_from_dynamic'),
+        ('msgs', '0033_auto_20160412_0839'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='outgoing',
+            name='contacts',
+            field=models.ManyToManyField(related_name='outgoing_messages', to='contacts.Contact'),
+        ),
+        migrations.AddField(
+            model_name='outgoing',
+            name='urns',
+            field=django.contrib.postgres.fields.ArrayField(default=list, base_field=models.CharField(max_length=255), size=None),
+        ),
+        migrations.AlterField(
+            model_name='outgoing',
+            name='backend_id',
+            field=models.IntegerField(help_text='Broadcast id from the backend', unique=True, null=True),
+        ),
+    ]

--- a/casepro/msgs/migrations/0035_populate_outgoing_contacts.py
+++ b/casepro/msgs/migrations/0035_populate_outgoing_contacts.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def populate_outgoing_contacts(apps, schema_editor):
+    Outgoing = apps.get_model('msgs', 'Outgoing')
+    for outgoing in Outgoing.objects.exclude(case=None).select_related('case__contact'):
+        outgoing.contacts.add(outgoing.case.contact)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0034_auto_20160512_1200'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_outgoing_contacts)
+    ]

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -408,6 +408,19 @@ class Outgoing(models.Model):
     case = models.ForeignKey('cases.Case', null=True, related_name="outgoing_messages")
 
     @classmethod
+    def create_case_reply(cls, org, user, text, case):
+        return cls.create(org, user, cls.CASE_REPLY, text, [case.contact], [], case)
+
+    @classmethod
+    def create_bulk_reply(cls, org, user, text, messages):
+        contacts = [m.contact for m in messages]
+        return cls.create(org, user, cls.BULK_REPLY, text, contacts, [], None)
+
+    @classmethod
+    def create_forward(cls, org, user, text, urns, original_message):
+        return cls.create(org, user, cls.FORWARD, text, [], urns, None)
+
+    @classmethod
     def create(cls, org, user, activity, text, contacts, urns, case=None):
         if not text:
             raise ValueError("Message text cannot be empty")

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -5,9 +5,11 @@ import json
 from dash.orgs.models import Org
 from dash.utils import chunks
 from django.contrib.auth.models import User
+from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+from django.utils.timezone import now
 from enum import Enum
 from redis_cache import get_redis_connection
 
@@ -397,7 +399,11 @@ class Outgoing(models.Model):
 
     text = models.TextField(max_length=640, null=True)
 
-    backend_id = models.IntegerField(unique=True, help_text=_("Broadcast id from the backend"))
+    backend_id = models.IntegerField(null=True, unique=True, help_text=_("Broadcast id from the backend"))
+
+    contacts = models.ManyToManyField(Contact, related_name='outgoing_messages')
+
+    urns = ArrayField(base_field=models.CharField(max_length=255), default=list)
 
     recipient_count = models.PositiveIntegerField()
 
@@ -418,6 +424,8 @@ class Outgoing(models.Model):
 
     @classmethod
     def create_forward(cls, org, user, text, urns, original_message):
+        # TODO store reference to original message ?
+
         return cls.create(org, user, cls.FORWARD, text, [], urns, None)
 
     @classmethod
@@ -427,15 +435,20 @@ class Outgoing(models.Model):
         if not contacts and not urns:
             raise ValueError("Message must have at least one recipient")
 
-        backend_id, backend_created_on = get_backend().create_outgoing(org, text, list(contacts), urns)
+        outgoing = cls.objects.create(org=org,
+                                      activity=activity,
+                                      text=text,
+                                      urns=urns,
+                                      recipient_count=len(contacts) + len(urns),
+                                      case=case,
+                                      created_by=user,
+                                      created_on=now())
 
-        return cls.objects.create(org=org,
-                                  backend_id=backend_id,
-                                  recipient_count=len(contacts) + len(urns),
-                                  activity=activity, case=case,
-                                  text=text,
-                                  created_by=user,
-                                  created_on=backend_created_on)
+        outgoing.contacts.add(*contacts)
+
+        get_backend().push_outgoing(org, outgoing)
+
+        return outgoing
 
     def as_json(self):
         """

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -11,7 +11,7 @@ from smartmin.views import SmartListView, SmartCreateView, SmartUpdateView, Smar
 from temba_client.utils import parse_iso8601
 
 from casepro.rules.models import ContainsTest, GroupsTest, Quantifier
-from casepro.utils import parse_csv, str_to_bool, json_encode
+from casepro.utils import parse_csv, str_to_bool, json_encode, JSONEncoder
 from casepro.utils.export import BaseDownloadView
 
 from .forms import LabelForm
@@ -178,7 +178,7 @@ class MessageCRUDL(SmartCRUDL):
             return JsonResponse({
                 'results': [m.as_json() for m in context['object_list']],
                 'has_more': context['has_more']
-            })
+            }, encoder=JSONEncoder)
 
     class Action(OrgPermsMixin, View):
         """
@@ -288,7 +288,7 @@ class MessageCRUDL(SmartCRUDL):
         def get(self, request, *args, **kwargs):
             message = Message.objects.get(org=request.org, backend_id=int(kwargs['id']))
             actions = [a.as_json() for a in message.get_history()]
-            return JsonResponse({'actions': actions})
+            return JsonResponse({'actions': actions}, encoder=JSONEncoder)
 
 
 class MessageExportCRUDL(SmartCRUDL):

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -325,6 +325,7 @@ GROUP_PERMISSIONS = {
         'orgs.org_inbox',
 
         'msgs.label.*',
+        'msgs.message.*',
         'msgs.messageexport.*',
 
         'cases.case.*',
@@ -339,6 +340,8 @@ GROUP_PERMISSIONS = {
     "Editors": (
         'orgs.org_inbox',
 
+        'msgs.message_bulk_reply',
+        'msgs.message_forward',
         'msgs.messageexport_create',
         'msgs.messageexport_read',
 
@@ -357,6 +360,8 @@ GROUP_PERMISSIONS = {
     "Viewers": (
         'orgs.org_inbox',
 
+        'msgs.message_bulk_reply',
+        'msgs.message_forward',
         'msgs.messageexport_create',
         'msgs.messageexport_read',
 

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -320,7 +320,7 @@ controllers.controller 'MessagesController', [ '$scope', '$timeout', '$modal', '
       maxLength: () -> OUTGOING_TEXT_MAX_LEN,
     }})
     .result.then((data) ->
-      MessageService.forwardToUrn(data.text, data.urn, () ->
+      MessageService.forwardMessage(message, data.text, data.urn, () ->
         UtilsService.displayAlert('success', "Message forwarded to " + data.urn.path)
       )
     )
@@ -459,7 +459,7 @@ controllers.controller 'CaseController', [ '$scope', '$window', '$timeout', 'Cas
     $scope.sending = true
 
     try
-      MessageService.replyInCase($scope.newMessage, $scope.caseObj, () ->
+      CaseService.replyToCase($scope.caseObj, $scope.newMessage, () ->
         $scope.newMessage = ''
         $scope.sending = false
         $scope.$broadcast('timelineChanged')

--- a/static/coffee/modals.coffee
+++ b/static/coffee/modals.coffee
@@ -136,7 +136,7 @@ modals.controller('ComposeModalController', ['$scope', '$modalInstance', 'title'
 
     if $scope.form.$valid
       urn = {scheme: $scope.fields.urn.scheme, path: $scope.fields.urn.path, urn: ($scope.fields.urn.scheme + ':' + $scope.fields.urn.path)}
-      $modalInstance.close({text: $scope.fields.text, urn: urn})
+      $modalInstance.close({text: $scope.fields.text.val, urn: urn})
 
   $scope.cancel = () -> $modalInstance.dismiss('cancel')
 


### PR DESCRIPTION
- Splits the generic message sending endpoint into three more logical endpoints for case replies, bulk replies and forwards
- Records contacts and URNs on the outgoing message
- Fixes a bug on the forwarding modal dialog