### PR TITLE
Basic contact page and contact displayer/identifier changes

### DIFF
--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -42,7 +42,7 @@ class ContactSyncer(BaseSyncer):
         return {
             'org': org,
             'uuid': remote.uuid,
-            'name': remote.name,
+            'name': remote.uuid[:6].upper(),  # we don't display contact names
             'language': remote.language,
             'is_blocked': remote.blocked,
             'is_stub': False,
@@ -52,9 +52,6 @@ class ContactSyncer(BaseSyncer):
 
     def update_required(self, local, remote, remote_as_kwargs):
         if local.is_stub:
-            return True
-
-        if local.name != remote.name:
             return True
 
         if local.language != remote.language:

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -42,7 +42,7 @@ class ContactSyncer(BaseSyncer):
         return {
             'org': org,
             'uuid': remote.uuid,
-            'name': remote.uuid[:6].upper(),  # we don't display contact names
+            'name': remote.name,
             'language': remote.language,
             'is_blocked': remote.blocked,
             'is_stub': False,
@@ -51,10 +51,7 @@ class ContactSyncer(BaseSyncer):
         }
 
     def update_required(self, local, remote, remote_as_kwargs):
-        if local.is_stub:
-            return True
-
-        if local.language != remote.language:
+        if local.is_stub or local.name != remote.name or local.language != remote.language:
             return True
 
         if {g.uuid for g in local.groups.all()} != {g.uuid for g in remote.groups}:

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -742,7 +742,7 @@ class RapidProBackendTest(BaseCasesTest):
         self.assertEqual(messages, [
             {
                 'id': 201,  # id is the broadcast id
-                'contact': {'uuid': "C-001", 'name': "Ann"},
+                'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urns': [],
                 'text': "Welcome",
                 'time': d3,

--- a/casepro/cases/context_processors.py
+++ b/casepro/cases/context_processors.py
@@ -4,23 +4,6 @@ import regex
 import time
 
 from django.conf import settings
-from urlparse import urlparse
-
-
-def contact_ext_url(request):
-    """
-    Context processor that adds values for constructing external contact URLs
-    """
-    # base URL for external contact links
-    if '://' in settings.SITE_API_HOST:
-        # host link is a full URL
-        components = urlparse(settings.SITE_API_HOST)
-        contact_ext_url_base = '%s://%s/contact/read/{}/' % (components.scheme, components.netloc)
-    else:
-        # host link is a host name
-        contact_ext_url_base = 'https://%s/contact/read/{}/' % settings.SITE_API_HOST
-
-    return {'contact_ext_url': contact_ext_url_base}
 
 
 def sentry_dsn(request):

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -22,7 +22,7 @@ from casepro.profiles import ROLE_ANALYST, ROLE_MANAGER
 from casepro.test import BaseCasesTest
 from casepro.utils import datetime_to_microseconds, microseconds_to_datetime
 
-from .context_processors import contact_ext_url, sentry_dsn
+from .context_processors import sentry_dsn
 from .models import AccessLevel, Case, CaseAction, CaseExport, Partner
 
 
@@ -543,7 +543,7 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json, {
             'id': self.case.pk,
-            'contact': {'uuid': "C-001", 'name': "Ann"},
+            'contact': {'id': self.ann.pk, 'name': "Ann"},
             'assignee': {'id': self.moh.pk, 'name': "MOH"},
             'labels': [{'id': self.aids.pk, 'name': "AIDS"}],
             'summary': "Summary",
@@ -578,7 +578,7 @@ class CaseCRUDLTest(BaseCasesTest):
         # backend has a message in the case time window that we don't have locally
         remote_message1 = {
             'id': 102,
-            'contact': {'uuid': "C-001", 'name': "Ann"},
+            'contact': {'id': self.ann.pk, 'name': "Ann"},
             'urns': [],
             'text': "Non casepro message...",
             'time': d2,
@@ -600,11 +600,11 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(len(response.json['results']), 3)
         self.assertEqual(response.json['results'][0]['type'], 'M')
         self.assertEqual(response.json['results'][0]['item']['text'], "What is AIDS?")
-        self.assertEqual(response.json['results'][0]['item']['contact'], {'uuid': "C-001", 'name': "Ann"})
+        self.assertEqual(response.json['results'][0]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
         self.assertEqual(response.json['results'][0]['item']['direction'], 'I')
         self.assertEqual(response.json['results'][1]['type'], 'M')
         self.assertEqual(response.json['results'][1]['item']['text'], "Non casepro message...")
-        self.assertEqual(response.json['results'][1]['item']['contact'], {'uuid': "C-001", 'name': "Ann"})
+        self.assertEqual(response.json['results'][1]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
         self.assertEqual(response.json['results'][1]['item']['direction'], 'O')
         self.assertEqual(response.json['results'][2]['type'], 'A')
         self.assertEqual(response.json['results'][2]['item']['action'], 'O')
@@ -698,7 +698,7 @@ class CaseCRUDLTest(BaseCasesTest):
         mock_fetch_contact_messages.return_value = [
             {
                 'id': 202,
-                'contact': {'uuid': "C-001", 'name': "Ann"},
+                'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urns': [],
                 'text': "It's bad",
                 'time': d3,
@@ -716,11 +716,11 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(len(items), 7)
         self.assertEqual(items[0]['type'], 'M')
         self.assertEqual(items[0]['item']['text'], "What is AIDS?")
-        self.assertEqual(items[0]['item']['contact'], {'uuid': "C-001", 'name': "Ann"})
+        self.assertEqual(items[0]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
         self.assertEqual(items[0]['item']['direction'], 'I')
         self.assertEqual(items[1]['type'], 'M')
         self.assertEqual(items[1]['item']['text'], "Non casepro message...")
-        self.assertEqual(items[1]['item']['contact'], {'uuid': "C-001", 'name': "Ann"})
+        self.assertEqual(items[1]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
         self.assertEqual(items[1]['item']['direction'], 'O')
         self.assertEqual(items[1]['item']['sender'], None)
         self.assertEqual(items[2]['type'], 'A')
@@ -818,17 +818,11 @@ class HomeViewsTest(BaseCasesTest):
         response = self.url_get('unicef', url)
         self.assertEqual(response.status_code, 200)
 
-        # should provide external contact links
-        self.assertContains(response, "http://localhost:8001/contact/read/{}/")
-
         # log in as regular user
         self.login(self.user1)
 
         response = self.url_get('unicef', url)
         self.assertEqual(response.status_code, 200)
-
-        # should not provide external contact links
-        self.assertNotContains(response, "http://localhost:8001/contact/read/{}/")
 
 
 class PartnerTest(BaseCasesTest):
@@ -941,12 +935,6 @@ class PartnerCRUDLTest(BaseCasesTest):
 
 
 class ContextProcessorsTest(BaseCasesTest):
-    def test_contact_ext_url(self):
-        with self.settings(SITE_API_HOST='http://localhost:8001/api/v1'):
-            self.assertEqual(contact_ext_url(None), {'contact_ext_url': 'http://localhost:8001/contact/read/{}/'})
-        with self.settings(SITE_API_HOST='rapidpro.io'):
-            self.assertEqual(contact_ext_url(None), {'contact_ext_url': 'https://rapidpro.io/contact/read/{}/'})
-
     def test_sentry_dsn(self):
         dsn = 'https://ir78h8v3mhz91lzgd2icxzaiwtmpsx10:58l883tax2o5cae05bj517f9xmq16a2h@app.getsentry.com/44864'
         with self.settings(SENTRY_DSN=dsn):

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from dash.orgs.models import Org
+from django.conf import settings
 from django.contrib.postgres.fields import HStoreField
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
@@ -172,6 +173,16 @@ class Contact(models.Model):
     def lock(cls, org, uuid):
         return get_redis_connection().lock(CONTACT_LOCK_KEY % (org.pk, uuid), timeout=60)
 
+    def get_display_name(self):
+        """
+        Gets the display name of this contact. If name is empty or site uses anonymous contacts, this is generated from
+        the backend UUID.
+        """
+        if not self.name or getattr(settings, 'SITE_ANON_CONTACTS', False):
+            return self.uuid[:6].upper()
+        else:
+            return self.name
+
     def get_fields(self, visible=None):
         fields = self.fields if self.fields else {}
 
@@ -245,7 +256,7 @@ class Contact(models.Model):
         """
         Prepares a contact for JSON serialization
         """
-        result = {'id': self.pk, 'name': self.name}
+        result = {'id': self.pk, 'name': self.get_display_name()}
 
         if full:
             result['fields'] = self.get_fields(visible=True)
@@ -253,4 +264,4 @@ class Contact(models.Model):
         return result
 
     def __str__(self):
-        return self.name if self.name else self.uuid
+        return self.get_display_name()

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -245,7 +245,7 @@ class Contact(models.Model):
         """
         Prepares a contact for JSON serialization
         """
-        result = {'uuid': self.uuid, 'name': self.name}
+        result = {'id': self.pk, 'name': self.name}
 
         if full:
             result['fields'] = self.get_fields(visible=True)

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from dash.orgs.models import TaskState
 from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
 from mock import patch
 
 from casepro.test import BaseCasesTest
@@ -12,8 +13,15 @@ from .tasks import pull_contacts
 
 
 class ContactTest(BaseCasesTest):
+    def setUp(self):
+        super(ContactTest, self).setUp()
+
+        self.ann = self.create_contact(self.unicef, '7b7dd838-4947-4e85-9b5c-0e8b1794080b', "Ann", [self.reporters],
+                                       {'age': "32", 'state': "WA"})
+
     def test_save(self):
-        # start with no groups or fields
+        # start with no data
+        Contact.objects.all().delete()
         Group.objects.all().delete()
         Field.objects.all().delete()
 
@@ -55,32 +63,42 @@ class ContactTest(BaseCasesTest):
 
         self.assertEqual(set(contact.groups.all()), {spammers, boffins})
 
-    def test_get_fields(self):
-        contact = self.create_contact(self.unicef, 'C-001', "Jean", fields={'age': "32", 'state': "WA"})
+    def test_get_display_name(self):
+        self.assertEqual(self.ann.get_display_name(), "Ann")
 
-        self.assertEqual(contact.get_fields(), {'age': "32", 'state': "WA"})  # what is stored on the contact
-        self.assertEqual(contact.get_fields(visible=True), {'nickname': None, 'age': "32"})  # visible fields
+        # if site uses anon contacts then obscure this
+        with override_settings(SITE_ANON_CONTACTS=True):
+            self.assertEqual(self.ann.get_display_name(), "7B7DD8")
+
+        # likewise if name if empty
+        self.ann.name = ""
+        self.assertEqual(self.ann.get_display_name(), "7B7DD8")
+
+    def test_get_fields(self):
+        self.assertEqual(self.ann.get_fields(), {'age': "32", 'state': "WA"})  # what is stored on the contact
+        self.assertEqual(self.ann.get_fields(visible=True), {'nickname': None, 'age': "32"})  # visible fields
 
     def test_release(self):
-        contact = self.create_contact(self.unicef, 'C-001', "Jean", [self.reporters], {'age': "32"})
-        self.create_message(self.unicef, 101, contact, "Hello")
-        self.create_message(self.unicef, 102, contact, "Goodbye")
+        self.create_message(self.unicef, 101, self.ann, "Hello")
+        self.create_message(self.unicef, 102, self.ann, "Goodbye")
 
-        contact.release()
+        self.ann.release()
 
-        self.assertEqual(contact.groups.count(), 0)  # should be removed from groups
-        self.assertEqual(contact.incoming_messages.count(), 2)  # messages should be inactive and handled
-        self.assertEqual(contact.incoming_messages.filter(is_active=False, is_handled=True).count(), 2)
+        self.assertEqual(self.ann.groups.count(), 0)  # should be removed from groups
+        self.assertEqual(self.ann.incoming_messages.count(), 2)  # messages should be inactive and handled
+        self.assertEqual(self.ann.incoming_messages.filter(is_active=False, is_handled=True).count(), 2)
 
     def test_as_json(self):
-        contact = self.create_contact(self.unicef, 'C-001', "Richard", fields={'age': "32", 'state': "WA"})
-
-        self.assertEqual(contact.as_json(full=False), {'id': contact.pk, 'name': "Richard"})
+        self.assertEqual(self.ann.as_json(full=False), {'id': self.ann.pk, 'name': "Ann"})
 
         # full=True means include visible contact fields
-        self.assertEqual(contact.as_json(full=True), {'id': contact.pk,
-                                                      'name': "Richard",
-                                                      'fields': {'nickname': None, 'age': "32"}})
+        self.assertEqual(self.ann.as_json(full=True), {'id': self.ann.pk,
+                                                       'name': "Ann",
+                                                       'fields': {'nickname': None, 'age': "32"}})
+
+        # if site uses anon contacts then name is obscured
+        with override_settings(SITE_ANON_CONTACTS=True):
+            self.assertEqual(self.ann.as_json(full=False), {'id': self.ann.pk, 'name': "7B7DD8"})
 
 
 class ContactCRUDLTest(BaseCasesTest):

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -160,7 +160,7 @@ class Message(models.Model):
         label_id = search.get('label')
         include_archived = search.get('include_archived')
         text = search.get('text')
-        contact_uuid = search.get('contact')
+        contact_id = search.get('contact')
         group_uuids = search.get('groups')
         after = search.get('after')
         before = search.get('before')
@@ -209,8 +209,8 @@ class Message(models.Model):
         if text:
             queryset = queryset.filter(text__icontains=text)
 
-        if contact_uuid:
-            queryset = queryset.filter(contact__uuid=contact_uuid)
+        if contact_id:
+            queryset = queryset.filter(contact__pk=contact_id)
         if group_uuids:
             queryset = queryset.filter(contact__groups__uuid__in=group_uuids).distinct()
 
@@ -465,7 +465,7 @@ class Outgoing(models.Model):
     @classmethod
     def search(cls, org, user, search):
         text = search.get('text')
-        contact_uuid = search.get('contact')
+        contact_id = search.get('contact')
 
         queryset = org.outgoing_messages.all()
 
@@ -476,8 +476,8 @@ class Outgoing(models.Model):
         if text:
             queryset = queryset.filter(text__icontains=text)
 
-        if contact_uuid:
-            queryset = queryset.filter(contact__uuid=contact_uuid)
+        if contact_id:
+            queryset = queryset.filter(contact__pk=contact_id)
 
         queryset = queryset.select_related('partner', 'contact', 'case__assignee', 'created_by__profile')
 
@@ -496,9 +496,7 @@ class Outgoing(models.Model):
             queryset = queryset.filter(partner=user_partner)
 
         if partner_id:
-            from casepro.cases.models import Partner
-            partner = Partner.objects.get(pk=partner_id)
-            queryset = queryset.filter(partner=partner)
+            queryset = queryset.filter(partner__pk=partner_id)
 
         if after:
             queryset = queryset.filter(created_on__gte=after)

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -543,7 +543,7 @@ class MessageTest(BaseCasesTest):
 
         self.assertEqual(msg.as_json(), {
             'id': msg.backend_id,
-            'contact': {'uuid': "C-001", 'name': "Ann"},
+            'contact': {'id': self.ann.pk, 'name': "Ann"},
             'text': "Hello",
             'time': msg.created_on,
             'labels': [{'id': self.aids.pk, 'name': "AIDS"}],
@@ -603,7 +603,7 @@ class MessageCRUDLTest(BaseCasesTest):
         self.assertEqual(len(response.json['results']), 3)
         self.assertEqual(response.json['results'][0]['id'], 103)
         self.assertEqual(response.json['results'][1]['id'], 102)
-        self.assertEqual(response.json['results'][1]['contact'], {'uuid': "C-002", 'name': "Bob"})
+        self.assertEqual(response.json['results'][1]['contact'], {'id': self.bob.pk, 'name': "Bob"})
         self.assertEqual(response.json['results'][1]['text'], "I ♡ RapidPro")
         self.assertEqual(response.json['results'][1]['labels'], [{'id': self.pregnancy.pk, 'name': "Pregnancy"}])
         self.assertEqual(response.json['results'][2]['id'], 101)
@@ -616,7 +616,7 @@ class MessageCRUDLTest(BaseCasesTest):
 
         self.assertEqual(len(response.json['results']), 2)
         self.assertEqual(response.json['results'][0]['id'], 105)
-        self.assertEqual(response.json['results'][0]['contact'], {'uuid': "C-003", 'name': "Cat"})
+        self.assertEqual(response.json['results'][0]['contact'], {'id': cat.pk, 'name': "Cat"})
         self.assertEqual(response.json['results'][0]['text'], "AIDS??")
         self.assertEqual(response.json['results'][0]['labels'], [{'id': self.aids.pk, 'name': "AIDS"}])
         self.assertEqual(response.json['results'][0]['case'], {'id': case.pk,
@@ -934,7 +934,7 @@ class OutgoingTest(BaseCasesTest):
 
         self.assertEqual(outgoing.as_json(), {
             'id': outgoing.pk,
-            'contact': {'uuid': "C-001", 'name': "Ann"},
+            'contact': {'id': self.ann.pk, 'name': "Ann"},
             'urns': [],
             'text': "That's great",
             'time': outgoing.created_on,
@@ -970,7 +970,7 @@ class OutgoingCRUDLTest(BaseCasesTest):
         self.assertEqual(response.json['results'], [
             {
                 'id': out2.pk,
-                'contact': {'name': "Ann", 'uuid': "C-001"},
+                'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urns': [],
                 'text': "Hello 2",
                 'direction': 'O',
@@ -980,7 +980,7 @@ class OutgoingCRUDLTest(BaseCasesTest):
             },
             {
                 'id': out1.pk,
-                'contact': {'name': "Ann", 'uuid': "C-001"},
+                'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urns': [],
                 'text': "Hello 1",
                 'direction': 'O',
@@ -997,7 +997,7 @@ class OutgoingCRUDLTest(BaseCasesTest):
         self.assertEqual(response.json['results'], [
             {
                 'id': out2.pk,
-                'contact': {'name': "Ann", 'uuid': "C-001"},
+                'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urns': [],
                 'text': "Hello 2",
                 'direction': 'O',
@@ -1033,7 +1033,7 @@ class OutgoingCRUDLTest(BaseCasesTest):
         self.assertEqual(response.json['results'], [
             {
                 'id': out2.pk,
-                'contact': {'name': "Bob", 'uuid': "C-002"},
+                'contact': {'id': self.bob.pk, 'name': "Bob"},
                 'urns': [],
                 'text': "Hello 2",
                 'direction': 'O',
@@ -1049,7 +1049,7 @@ class OutgoingCRUDLTest(BaseCasesTest):
             },
             {
                 'id': out1.pk,
-                'contact': {'name': "Ann", 'uuid': "C-001"},
+                'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urns': [],
                 'text': "Hello 1",
                 'direction': 'O',

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -397,7 +397,7 @@ class MessageTest(BaseCasesTest):
         self.assertRaises(ValueError, Message.search, self.unicef, self.user1, {'folder': MessageFolder.unlabelled})
 
         # by contact in the inbox
-        assert_search(self.admin, {'folder': MessageFolder.inbox, 'contact': bob.uuid}, [msg8, msg6])
+        assert_search(self.admin, {'folder': MessageFolder.inbox, 'contact': bob.pk}, [msg8, msg6])
 
         # by contact group in the inbox
         assert_search(self.admin, {'folder': MessageFolder.inbox, 'groups': [self.reporters.uuid]}, [msg8, msg6])
@@ -901,7 +901,7 @@ class OutgoingTest(BaseCasesTest):
         assert_search(self.admin, {'folder': OutgoingFolder.sent, 'text': "LO 5"}, [out5])
 
         # by contact
-        assert_search(self.admin, {'folder': OutgoingFolder.sent, 'contact': self.ann.uuid}, [out2, out1])
+        assert_search(self.admin, {'folder': OutgoingFolder.sent, 'contact': self.ann.pk}, [out2, out1])
 
     def test_search_replies(self):
         out1 = self.create_outgoing(self.unicef, self.admin, 201, 'B', "Hello 1", self.ann)

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -53,9 +53,12 @@ SITE_ALLOW_NO_ORG = ('orgs_ext.org_create', 'orgs_ext.org_update', 'orgs_ext.org
                      'orgs_ext.task_list',
                      'profiles.user_create', 'profiles.user_update', 'profiles.user_read', 'profiles.user_list',
                      'internal.status', 'internal.ping')
+
+# casepro configuration
 SITE_ORGS_STORAGE_ROOT = 'orgs'
 SITE_EXTERNAL_CONTACT_URL = 'http://localhost:8001/contact/read/%s/'
 SITE_BACKEND = 'casepro.backend.rapidpro.RapidProBackend'
+SITE_ANON_CONTACTS = False
 
 
 # On Unix systems, a value of None will cause Django to use the same

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -54,6 +54,7 @@ SITE_ALLOW_NO_ORG = ('orgs_ext.org_create', 'orgs_ext.org_update', 'orgs_ext.org
                      'profiles.user_create', 'profiles.user_update', 'profiles.user_read', 'profiles.user_list',
                      'internal.status', 'internal.ping')
 SITE_ORGS_STORAGE_ROOT = 'orgs'
+SITE_EXTERNAL_CONTACT_URL = 'http://localhost:8001/contact/read/%s/'
 SITE_BACKEND = 'casepro.backend.rapidpro.RapidProBackend'
 
 
@@ -166,7 +167,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'dash.orgs.context_processors.user_group_perms_processor',
     'dash.orgs.context_processors.set_org_processor',
     'dash.context_processors.lang_direction',
-    'casepro.cases.context_processors.contact_ext_url',
     'casepro.cases.context_processors.sentry_dsn',
     'casepro.cases.context_processors.server_time',
     'casepro.profiles.context_processors.user_is_admin',
@@ -319,6 +319,8 @@ PERMISSIONS = {
 
     'cases.partner': ('create', 'read', 'delete', 'list', 'users'),
 
+    'contacts.contact': ('read', 'list'),
+
     'contacts.group': ('select', 'list'),
 
     # can't create profiles.user.* permissions because we don't own User
@@ -342,6 +344,7 @@ GROUP_PERMISSIONS = {
         'cases.caseexport.*',
         'cases.partner.*',
 
+        'contacts.contact_read',
         'contacts.group.*',
         'contacts.field.*',
 
@@ -374,6 +377,8 @@ GROUP_PERMISSIONS = {
         'cases.partner_read',
         'cases.partner_users',
 
+        'contacts.contact_read',
+
         'profiles.profile_user_create',
         'profiles.profile_user_read',
     ),
@@ -403,6 +408,8 @@ GROUP_PERMISSIONS = {
         'cases.partner_list',
         'cases.partner_read',
         'cases.partner_users',
+
+        'contacts.contact_read',
 
         'profiles.profile_user_read',
     ),

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -203,7 +203,7 @@ services.factory 'MessageService', ['$rootScope', '$http', ($rootScope, $http) -
         after: formatIso8601(search.after),
         before: formatIso8601(search.before),
         groups: (g.uuid for g in search.groups).join(','),
-        contact: if search.contact then search.contact.uuid else null,
+        contact: if search.contact then search.contact.id else null,
         label: if search.label then search.label.id else null,
         archived: if search.archived then 1 else 0
       }
@@ -281,7 +281,7 @@ services.factory 'OutgoingService', ['$rootScope', '$http', ($rootScope, $http) 
       return {
         folder: search.folder,
         text: search.text,
-        contact: if search.contact then search.contact.uuid else null,
+        contact: if search.contact then search.contact.id else null,
         before: formatIso8601(startTime),
         page: page
       }

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -140,14 +140,8 @@
         .panel.panel-default{ ng-if:"caseObj.contact" }
           .panel-heading
             - trans "Contact"
-            %strong
+            %a{ ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
               [[ caseObj.contact.name ]]
-
-            - if user_is_admin
-              &nbsp;
-              %a{ ng-href:ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
-                %span.glyphicon.glyphicon-new-window
-                - trans "View"
           .panel-body
             .contact-details
               .none{ ng-if:"!caseObj.contact.fields" }

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -141,11 +141,11 @@
           .panel-heading
             - trans "Contact"
             %strong
-              [[ caseObj.contact.uuid | limitTo:6 | uppercase ]]
+              [[ caseObj.contact.name ]]
 
             - if user_is_admin
               &nbsp;
-              %a{ ng-href:'[[ "{{ contact_ext_url }}" | replace:"{}":caseObj.contact.uuid ]]', target:"_blank" }
+              %a{ ng-href:ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
                 %span.glyphicon.glyphicon-new-window
                 - trans "View"
           .panel-body

--- a/templates/cases/home_messages.haml
+++ b/templates/cases/home_messages.haml
@@ -10,12 +10,11 @@
           %span.contact-info
             Messages for contact
             %strong
-              [[ activeContact.uuid | limitTo:6 | uppercase ]]
+              [[ activeContact.name ]]
 
             - if user_is_admin
               &nbsp;
-              %a{ ng-href:'[[ "{{ contact_ext_url }}" | replace:"{}":activeContact.uuid ]]', target:"_blank" }
-                %span.glyphicon.glyphicon-new-window
+              %a{ ng-href:"/contact/read/[[ activeContact.id ]]/" }
                 - trans "View"
           .pull-away
             %button.btn.btn-default{ type:"button", ng-click:"activateContact(null)" }
@@ -143,7 +142,7 @@
         .message-contact
           %a{ ng-click:"activateContact(message.contact)", title:"View all from contact" }><
             %span.glyphicon.glyphicon-phone>
-            [[ message.contact.uuid | limitTo:6 | uppercase ]]
+            [[ message.contact.name ]]
         .message-text{ ng-click:"onExpandMessage(message)" }
           %span.label-container{ ng-if:"message.flow" }
             %span.label.label-info

--- a/templates/cases/home_outgoing.haml
+++ b/templates/cases/home_outgoing.haml
@@ -10,12 +10,11 @@
           %span.contact-info
             Messages for contact
             %strong
-              [[ activeContact.uuid | limitTo:6 | uppercase ]]
+              [[ activeContact.name ]]
 
             - if user_is_admin
               &nbsp;
-              %a{ ng-href:'[[ "{{ contact_ext_url }}" | replace:"{}":activeContact.uuid ]]', target:"_blank" }
-                %span.glyphicon.glyphicon-new-window
+              %a{ ng-href:"/contact/read/[[ activeContact.id ]]/" }
                 - trans "View"
           .pull-away
             %button.btn.btn-default{ type:"button", ng-click:"activateContact(null)" }
@@ -42,7 +41,7 @@
           %span{ ng-if:"item.contact" }
             %a{ ng-click:"activateContact(item.contact)", title:"View all to contact", style:"white-space: nowrap;" }><
               %span.glyphicon.glyphicon-phone>
-              [[ item.contact.uuid | limitTo:6 | uppercase ]]
+              [[ item.contact.name ]]
           %span{ ng-if:"item.urns.length" }
             <ng-pluralize count="item.urns.length" when="{'one': '1 recipient', 'other': '{} recipients'}">
             </ng-pluralize>

--- a/templates/cases/partner_read.haml
+++ b/templates/cases/partner_read.haml
@@ -97,8 +97,9 @@
               %tbody
                 %tr{ ng-repeat:"item in items" }
                   %td{ nowrap:"" }
-                    %span.glyphicon.glyphicon-phone>
-                    [[ item.contact.uuid | limitTo:6 | uppercase ]]
+                    %a{ ng-href:"/contact/read/[[ item.contact.id ]]" }><
+                      %span.glyphicon.glyphicon-phone>
+                      [[ item.contact.name ]]
                   %td
                     %span.glyphicon.glyphicon-flag{ ng-if:"item.reply_to.flagged" }
                   %td

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -1,0 +1,19 @@
+- extends "smartmin/read.html"
+- load smartmin i18n thumbnail
+
+- block pre-content
+  .page-header.clearfix{ style:"border-bottom: none" }
+    .page-header-buttons
+      - if user_is_admin
+        %a.btn.btn-default{ href:"{{ backend_url }}", target:"_blank" }
+          %span.glyphicon.glyphicon-new-window
+          - trans "View External"
+
+    %h2
+      %span.glyphicon.glyphicon-phone
+      {{ title }}
+
+  <uib-tabset active="active">
+    <uib-tab index="0" heading="{% trans "Summary" %}"></uib-tab>
+  </uib-tabset>
+  <br/>


### PR DESCRIPTION
- Switches frontend code to reference contacts by local id rather than backend UUID (which they might not have in some deployments)
- Allows deployments to switch between displaying contact names and anonymous identifiers using setting
- Adds very basic contact read page:

<img width="774" alt="screen shot 2016-05-26 at 08 36 33" src="https://cloud.githubusercontent.com/assets/675558/15565929/5bbdc30e-231e-11e6-9ab2-68661d387c93.png">


