### PR TITLE
Allow some partners to have unrestricted label access

### DIFF
--- a/casepro/cases/forms.py
+++ b/casepro/cases/forms.py
@@ -9,14 +9,17 @@ from .models import Partner
 
 
 class PartnerForm(forms.ModelForm):
-    labels = forms.ModelMultipleChoiceField(label=_("Can Access"), queryset=Label.objects.none(), required=False)
+    labels = forms.ModelMultipleChoiceField(label=_("Can Access"),
+                                            queryset=Label.objects.none(),
+                                            widget=forms.CheckboxSelectMultiple(),
+                                            required=False)
 
     def __init__(self, *args, **kwargs):
         org = kwargs.pop('org')
         super(PartnerForm, self).__init__(*args, **kwargs)
 
-        self.fields['labels'].queryset = Label.get_all(org)
+        self.fields['labels'].queryset = Label.get_all(org).order_by('name')
 
     class Meta:
         model = Partner
-        fields = ('name', 'logo', 'labels')
+        fields = ('name', 'logo', 'is_restricted', 'labels')

--- a/casepro/cases/migrations/0036_partner_is_restricted.py
+++ b/casepro/cases/migrations/0036_partner_is_restricted.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cases', '0035_folder_indexes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='partner',
+            name='is_restricted',
+            field=models.BooleanField(default=True, help_text="Whether this partner's access is restricted by labels", verbose_name='Restricted Access'),
+        ),
+    ]

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -875,11 +875,11 @@ class HomeViewsTest(BaseCasesTest):
 
 class PartnerTest(BaseCasesTest):
     def test_create(self):
-        wfp = Partner.create(self.unicef, "WFP", [self.aids, self.code], None)
+        wfp = Partner.create(self.unicef, "WFP", True, [self.aids, self.pregnancy])
         self.assertEqual(wfp.org, self.unicef)
         self.assertEqual(wfp.name, "WFP")
         self.assertEqual(six.text_type(wfp), "WFP")
-        self.assertEqual(set(wfp.get_labels()), {self.aids, self.code})
+        self.assertEqual(set(wfp.get_labels()), {self.aids, self.pregnancy})
 
         # create some users for this partner
         jim = self.create_user(self.unicef, wfp, ROLE_MANAGER, "Jim", "jim@wfp.org")
@@ -888,6 +888,13 @@ class PartnerTest(BaseCasesTest):
         self.assertEqual(set(wfp.get_users()), {jim, kim})
         self.assertEqual(set(wfp.get_managers()), {jim})
         self.assertEqual(set(wfp.get_analysts()), {kim})
+
+        # create a partner which is not restricted by labels
+        internal = Partner.create(self.unicef, "Internal", False, [])
+        self.assertEqual(set(internal.get_labels()), {self.aids, self.pregnancy, self.tea})
+
+        # can't create an unrestricted partner with labels
+        self.assertRaises(ValueError, Partner.create, self.unicef, "Testers", False, [self.aids])
 
     def test_release(self):
         self.who.release()

--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -298,7 +298,7 @@ class PartnerCRUDL(SmartCRUDL):
         def save(self, obj):
             data = self.form.cleaned_data
             org = self.request.user.get_org()
-            restricted = data['restricted']
+            restricted = data['is_restricted']
             labels = data['labels'] if restricted else []
 
             self.object = Partner.create(org, data['name'], restricted, labels, data['logo'])

--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -124,7 +124,7 @@ class CaseCRUDL(SmartCRUDL):
             case.reassign(request.user, assignee)
             return HttpResponse(status=204)
 
-    class Close(OrgPermsMixin, SmartUpdateView):
+    class Close(OrgObjPermsMixin, SmartUpdateView):
         """
         JSON endpoint for closing a case
         """
@@ -187,7 +187,7 @@ class CaseCRUDL(SmartCRUDL):
             outgoing = case.reply(request.user, request.POST['text'])
             return JsonResponse({'id': outgoing.pk})
 
-    class Fetch(OrgPermsMixin, SmartReadView):
+    class Fetch(OrgObjPermsMixin, SmartReadView):
         """
         JSON endpoint for fetching a single case
         """
@@ -223,7 +223,7 @@ class CaseCRUDL(SmartCRUDL):
                 'has_more': context['has_more']
             }, encoder=JSONEncoder)
 
-    class Timeline(OrgPermsMixin, SmartReadView):
+    class Timeline(OrgObjPermsMixin, SmartReadView):
         """
         JSON endpoint for fetching case actions and messages
         """
@@ -298,7 +298,10 @@ class PartnerCRUDL(SmartCRUDL):
         def save(self, obj):
             data = self.form.cleaned_data
             org = self.request.user.get_org()
-            self.object = Partner.create(org, data['name'], data['labels'], data['logo'])
+            restricted = data['restricted']
+            labels = data['labels'] if restricted else []
+
+            self.object = Partner.create(org, data['name'], restricted, labels, data['logo'])
 
     class Update(OrgObjPermsMixin, PartnerFormMixin, SmartUpdateView):
         form_class = PartnerForm

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -64,11 +64,12 @@ class Label(models.Model):
 
     @classmethod
     def get_all(cls, org, user=None):
-        if not user or user.can_administer(org):
-            return cls.objects.filter(org=org, is_active=True)
+        if user:
+            user_partner = user.get_partner(org)
+            if user_partner and user_partner.is_restricted:
+                return user_partner.get_labels()
 
-        partner = user.get_partner(org)
-        return partner.get_labels() if partner else cls.objects.none()
+        return org.labels.filter(is_active=True)
 
     @classmethod
     def lock(cls, org, uuid):

--- a/casepro/orgs_ext/tests.py
+++ b/casepro/orgs_ext/tests.py
@@ -86,3 +86,17 @@ class OrgExtCRUDLTest(BaseCasesTest):
 
         self.assertEqual(set(Group.get_suspend_from(self.unicef)), {self.males})
         self.assertEqual(set(Field.get_all(self.unicef, visible=True)), {self.state})
+
+
+class TaskExtCRUDLTest(BaseCasesTest):
+    def test_list(self):
+        url = reverse('orgs_ext.task_list')
+
+        # not accessible to org users
+        self.login(self.admin)
+        self.assertLoginRedirect(self.url_get('unicef', url), 'unicef', url)
+
+        # accessible to superusers
+        self.login(self.superuser)
+        response = self.url_get('unicef', url)
+        self.assertEqual(response.status_code, 200)

--- a/casepro/test.py
+++ b/casepro/test.py
@@ -72,8 +72,8 @@ class BaseCasesTest(DashTest):
         self.state = self.create_field(self.unicef, 'state', "State", value_type='S', is_visible=False)
         self.motorbike = self.create_field(self.nyaruka, 'motorbike', "Moto", value_type='T')
 
-    def create_partner(self, org, name, labels=()):
-        return Partner.create(org, name, labels, None)
+    def create_partner(self, org, name, labels=(), restricted=True):
+        return Partner.create(org, name, restricted, labels, None)
 
     def create_admin(self, org, full_name, email):
         user = User.create(None, None, None, full_name, email, password=email, change_password=False)

--- a/templates/cases/partner_create.haml
+++ b/templates/cases/partner_create.haml
@@ -1,0 +1,14 @@
+- extends "smartmin/update.html"
+
+- block extra-script
+  {{ block.super }}
+  :javascript
+    $(function() {
+      function onToggleRestricted() {
+        $('#id_labels input[type="checkbox"]').prop("disabled", !$('#id_is_restricted').prop('checked'));
+      }
+      // if is_restricted is checked, enable label checkboxes
+      $('#id_is_restricted').on('change', onToggleRestricted);
+
+      onToggleRestricted();
+    });

--- a/templates/cases/partner_list.haml
+++ b/templates/cases/partner_list.haml
@@ -26,11 +26,12 @@
         .partner-name
           {{ partner.name }}
         .
-          - for label in partner.get_labels
-            %span.label-container
-              %span.label.label-success
-                {{ label.name }}
-              &nbsp;
+          - if partner.is_restricted
+            - for label in partner.get_labels
+              %span.label-container
+                %span.label.label-success
+                  {{ label.name }}
+                &nbsp;
 
 - block extra-style
   {{ block.super }}

--- a/templates/cases/partner_read.haml
+++ b/templates/cases/partner_read.haml
@@ -30,16 +30,17 @@
         %h2
           {{ object.name }}
 
-      .header-details
-        - if partner.get_labels
-          - for label in partner.get_labels
-            %span.label-container
-              %span.label.label-success
-                {{ label.name }}
-              &nbsp;
-        - else
-          %i
-            - trans "No labels"
+      - if object.is_restricted
+        .header-details
+          - if labels
+            - for label in labels
+              %span.label-container
+                %span.label.label-success
+                  {{ label.name }}
+                &nbsp;
+          - else
+            %i
+              - trans "No labels"
 
     <uib-tabset active="active">
 

--- a/templates/cases/partner_update.haml
+++ b/templates/cases/partner_update.haml
@@ -1,0 +1,14 @@
+- extends "smartmin/update.html"
+
+- block extra-script
+  {{ block.super }}
+  :javascript
+    $(function() {
+      function onToggleRestricted() {
+        $('#id_labels input[type="checkbox"]').prop("disabled", !$('#id_is_restricted').prop('checked'));
+      }
+      // if is_restricted is checked, enable label checkboxes
+      $('#id_is_restricted').on('change', onToggleRestricted);
+
+      onToggleRestricted();
+    });


### PR DESCRIPTION
Some UPartners offices have created partner orgs which they use internally and explicitly have access to all labels. This isn't ideal from a display or performance point-of-view especially when number of labels is high.

This should also serve Momconnect usecase where partners aren't restricted by labels.

Also changes partner form to use choeckboxes rather than dropdown as this makes it easier to see which labels are selected.