### PR TITLE
Use JSON for AJAX posts

### DIFF
--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -17,7 +17,7 @@ from temba_client.utils import parse_iso8601
 
 from casepro.contacts.models import Group
 from casepro.msgs.models import Label, Message, MessageFolder, Outgoing, OutgoingFolder
-from casepro.utils import parse_csv, json_encode, datetime_to_microseconds, microseconds_to_datetime, JSONEncoder
+from casepro.utils import json_encode, datetime_to_microseconds, microseconds_to_datetime, JSONEncoder
 from casepro.utils import month_range
 from casepro.utils.export import BaseDownloadView
 
@@ -84,15 +84,15 @@ class CaseCRUDL(SmartCRUDL):
         permission = 'cases.case_create'
 
         def post(self, request, *args, **kwargs):
-            summary = request.POST['summary']
+            summary = request.json['summary']
 
-            assignee_id = request.POST.get('assignee', None)
+            assignee_id = request.json.get('assignee', None)
             if assignee_id:
                 assignee = Partner.get_all(request.org).get(pk=assignee_id)
             else:
                 assignee = request.user.get_partner(self.request.org)
 
-            message_id = int(request.POST['message'])
+            message_id = int(request.json['message'])
             message = Message.objects.get(org=request.org, backend_id=message_id)
 
             case = Case.get_or_open(request.org, request.user, message, summary, assignee)
@@ -107,7 +107,7 @@ class CaseCRUDL(SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             case = self.get_object()
-            note = request.POST['note']
+            note = request.json['note']
 
             case.add_note(request.user, note)
             return HttpResponse(status=204)
@@ -119,7 +119,7 @@ class CaseCRUDL(SmartCRUDL):
         permission = 'cases.case_update'
 
         def post(self, request, *args, **kwargs):
-            assignee = Partner.get_all(request.org).get(pk=request.POST['assignee'])
+            assignee = Partner.get_all(request.org).get(pk=request.json['assignee'])
             case = self.get_object()
             case.reassign(request.user, assignee)
             return HttpResponse(status=204)
@@ -132,7 +132,7 @@ class CaseCRUDL(SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             case = self.get_object()
-            note = request.POST.get('note', None)
+            note = request.json.get('note')
             case.close(request.user, note)
 
             return HttpResponse(status=204)
@@ -145,7 +145,7 @@ class CaseCRUDL(SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             case = self.get_object()
-            note = request.POST.get('note', None)
+            note = request.json.get('note')
 
             case.reopen(request.user, note)
             return HttpResponse(status=204)
@@ -158,7 +158,7 @@ class CaseCRUDL(SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             case = self.get_object()
-            label_ids = parse_csv(request.POST.get('labels', ''), as_ints=True)
+            label_ids = request.json['labels']
             labels = Label.get_all(request.org).filter(pk__in=label_ids)
 
             case.update_labels(request.user, labels)
@@ -172,7 +172,7 @@ class CaseCRUDL(SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             case = self.get_object()
-            summary = request.POST['summary']
+            summary = request.json['summary']
             case.update_summary(request.user, summary)
             return HttpResponse(status=204)
 
@@ -184,7 +184,7 @@ class CaseCRUDL(SmartCRUDL):
 
         def post(self, request, *args, **kwargs):
             case = self.get_object()
-            outgoing = case.reply(request.user, request.POST['text'])
+            outgoing = case.reply(request.user, request.json['text'])
             return JsonResponse({'id': outgoing.pk})
 
     class Fetch(OrgObjPermsMixin, SmartReadView):

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -642,37 +642,37 @@ class MessageCRUDLTest(BaseCasesTest):
         # log in as a non-administrator
         self.login(self.user1)
 
-        response = self.url_post('unicef', get_url('flag'), {'messages': "102,103"})
+        response = self.url_post_json('unicef', get_url('flag'), {'messages': [102, 103]})
 
         self.assertEqual(response.status_code, 204)
         mock_flag_messages.assert_called_once_with(self.unicef, [msg2, msg3])
         self.assertEqual(Message.objects.filter(is_flagged=True).count(), 2)
 
-        response = self.url_post('unicef', get_url('unflag'), {'messages': "102"})
+        response = self.url_post_json('unicef', get_url('unflag'), {'messages': [102]})
 
         self.assertEqual(response.status_code, 204)
         mock_unflag_messages.assert_called_once_with(self.unicef, [msg2])
         self.assertEqual(Message.objects.filter(is_flagged=True).count(), 1)
 
-        response = self.url_post('unicef', get_url('archive'), {'messages': "102"})
+        response = self.url_post_json('unicef', get_url('archive'), {'messages': [102]})
 
         self.assertEqual(response.status_code, 204)
         mock_archive_messages.assert_called_once_with(self.unicef, [msg2])
         self.assertEqual(Message.objects.filter(is_archived=True).count(), 2)
 
-        response = self.url_post('unicef', get_url('restore'), {'messages': "103"})
+        response = self.url_post_json('unicef', get_url('restore'), {'messages': [103]})
 
         self.assertEqual(response.status_code, 204)
         mock_restore_messages.assert_called_once_with(self.unicef, [msg3])
         self.assertEqual(Message.objects.filter(is_archived=True).count(), 1)
 
-        response = self.url_post('unicef', get_url('label'), {'messages': "103", 'label': self.aids.pk})
+        response = self.url_post_json('unicef', get_url('label'), {'messages': [103], 'label': self.aids.pk})
 
         self.assertEqual(response.status_code, 204)
         mock_label_messages.assert_called_once_with(self.unicef, [msg3], self.aids)
         self.assertEqual(Message.objects.filter(labels=self.aids).count(), 2)
 
-        response = self.url_post('unicef', get_url('unlabel'), {'messages': "103", 'label': self.aids.pk})
+        response = self.url_post_json('unicef', get_url('unlabel'), {'messages': [103], 'label': self.aids.pk})
 
         self.assertEqual(response.status_code, 204)
         mock_unlabel_messages.assert_called_once_with(self.unicef, [msg3], self.aids)
@@ -688,7 +688,7 @@ class MessageCRUDLTest(BaseCasesTest):
         # log in as a non-administrator
         self.login(self.user1)
 
-        response = self.url_post('unicef', url, {'labels': [self.pregnancy.pk]})
+        response = self.url_post_json('unicef', url, {'labels': [self.pregnancy.pk]})
         self.assertEqual(response.status_code, 204)
 
         mock_label_messages.assert_called_once_with(self.unicef, [msg1], self.pregnancy)
@@ -710,7 +710,7 @@ class MessageCRUDLTest(BaseCasesTest):
         self.login(self.user1)
 
         # try replying to all three of Ann's messages and one of Bob's
-        response = self.url_post('unicef', url, {'text': "That's fine", 'messages': "102,103,101,104"})
+        response = self.url_post_json('unicef', url, {'text': "That's fine", 'messages': [102,103,101,104]})
         self.assertEqual(response.json['messages'], 2)
 
         outgoing = Outgoing.objects.all().order_by('contact__pk')
@@ -734,7 +734,9 @@ class MessageCRUDLTest(BaseCasesTest):
         # log in as a non-administrator
         self.login(self.user1)
 
-        response = self.url_post('unicef', url, {'text': "Check this out", 'urns': "tel:+2501234567,twitter:bob"})
+        response = self.url_post_json('unicef', url, {
+            'text': "Check this out", 'urns': ["tel:+2501234567", "twitter:bob"]
+        })
         out = Outgoing.objects.get(pk=response.json['id'])
 
         self.assertEqual(out.org, self.unicef)

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -710,7 +710,7 @@ class MessageCRUDLTest(BaseCasesTest):
         self.login(self.user1)
 
         # try replying to all three of Ann's messages and one of Bob's
-        response = self.url_post_json('unicef', url, {'text': "That's fine", 'messages': [102,103,101,104]})
+        response = self.url_post_json('unicef', url, {'text': "That's fine", 'messages': [102, 103, 101, 104]})
         self.assertEqual(response.json['messages'], 2)
 
         outgoing = Outgoing.objects.all().order_by('contact__pk')

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -198,10 +198,10 @@ class MessageCRUDL(SmartCRUDL):
 
             action = kwargs['action']
 
-            message_ids = parse_csv(request.POST.get('messages', ''), as_ints=True)
+            message_ids = request.json['messages']
             messages = org.incoming_messages.filter(org=org, backend_id__in=message_ids)
 
-            label_id = int(request.POST.get('label', 0))
+            label_id = request.json.get('label')
             label = Label.get_all(org, user).get(pk=label_id) if label_id else None
 
             if action == 'flag':
@@ -236,7 +236,7 @@ class MessageCRUDL(SmartCRUDL):
             message_id = int(kwargs['id'])
             message = org.incoming_messages.filter(org=org, backend_id=message_id).first()
 
-            label_ids = parse_csv(self.request.POST.get('labels', ''), as_ints=True)
+            label_ids = request.json['labels']
             labels = Label.get_all(org, user).filter(pk__in=label_ids)
 
             message.update_labels(user, labels)
@@ -252,8 +252,8 @@ class MessageCRUDL(SmartCRUDL):
             return r'^message/bulk_reply/$'
 
         def post(self, request, *args, **kwargs):
-            text = request.POST['text']
-            message_ids = parse_csv(request.POST.get('messages', ''), as_ints=False)
+            text = request.json['text']
+            message_ids = request.json['messages']
             messages = Message.objects.filter(org=request.org, backend_id__in=message_ids).select_related('contact')
 
             # organize messages by contact
@@ -279,9 +279,9 @@ class MessageCRUDL(SmartCRUDL):
             return r'^message/forward/(?P<id>\d+)/$'
 
         def post(self, request, *args, **kwargs):
-            text = request.POST['text']
+            text = request.json['text']
             message = Message.objects.get(org=request.org, backend_id=int(kwargs['id']))
-            urns = parse_csv(request.POST['urns'], as_ints=False)
+            urns = request.json['urns']
 
             out = Outgoing.create_forward(request.org, request.user, text, urns, message)
             return JsonResponse({'id': out.pk})

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -156,6 +156,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'dash.orgs.middleware.SetOrgMiddleware',
+    'casepro.utils.middleware.JSONMiddleware',
     'casepro.profiles.middleware.ForcePasswordChangeMiddleware',
 )
 

--- a/casepro/test.py
+++ b/casepro/test.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import json
+
 from casepro.backend import NoopBackend
 from casepro.cases.models import Case, Partner
 from casepro.contacts.models import Contact, Group, Field
@@ -129,6 +131,9 @@ class BaseCasesTest(DashTest):
         message.save(update_fields=('case',))
 
         return case
+
+    def url_post_json(self, subdomain, url, data):
+        return self.url_post(subdomain, url, json.dumps(data), content_type="application/json")
 
     def assertNotCalled(self, mock):
         """

--- a/casepro/utils/middleware.py
+++ b/casepro/utils/middleware.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+
+import json
+
+
+class JSONMiddleware(object):
+    """
+    Process application/json request data
+    """
+    def process_request(self, request):
+        if 'application/json' in request.META.get('CONTENT_TYPE', ""):
+            request.json = json.loads(request.body)

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -46,7 +46,7 @@ describe('services:', () ->
     
     describe('addNote', () ->
       it('posts to note endpoint', () ->
-        $httpBackend.expectPOST('/case/note/501/').respond('')
+        $httpBackend.expectPOST('/case/note/501/', {note: "Hello there"}).respond('')
         CaseService.addNote(test.case1, "Hello there")
         $httpBackend.flush()
       )
@@ -102,7 +102,7 @@ describe('services:', () ->
 
     describe('reassign', () ->
       it('posts to reassign endpoint', () ->
-        $httpBackend.expectPOST('/case/reassign/501/').respond('')
+        $httpBackend.expectPOST('/case/reassign/501/', {assignee: 302}).respond('')
         CaseService.reassign(test.case1, test.who).then(() ->
           expect(test.case1.assignee).toEqual(test.who)
         )
@@ -112,7 +112,7 @@ describe('services:', () ->
 
     describe('close', () ->
       it('posts to close endpoint and closes case', () ->
-        $httpBackend.expectPOST('/case/close/501/').respond('')
+        $httpBackend.expectPOST('/case/close/501/', {note: "Hello there"}).respond('')
         CaseService.close(test.case1, "Hello there").then(() ->
           expect(test.case1.is_closed).toEqual(true)
         )
@@ -122,7 +122,7 @@ describe('services:', () ->
 
     describe('open', () ->
       it('posts to open endpoint', () ->
-        $httpBackend.expectPOST('/case/open/').respond('{"case": {"id": 501}, "is_new": true}')
+        $httpBackend.expectPOST('/case/open/', {message: 401, summary: "Hi", assignee: 301}).respond('{"case": {"id": 501}, "is_new": true}')
         CaseService.open({id: 401, text: "Hi"}, "Hi", test.moh).then((caseObj) ->
           expect(caseObj.id).toEqual(501)
           expect(caseObj.isNew).toEqual(true)
@@ -133,7 +133,7 @@ describe('services:', () ->
 
     describe('relabel', () ->
       it('posts to label endpoint', () ->
-        $httpBackend.expectPOST('/case/label/501/').respond('')
+        $httpBackend.expectPOST('/case/label/501/', {labels: [202]}).respond('')
         CaseService.relabel(test.case1, [test.coffee]).then(() ->
           expect(test.case1.labels).toEqual([test.coffee])
         )
@@ -145,7 +145,7 @@ describe('services:', () ->
       it('posts to reopen endpoint and reopens case', () ->
         test.case1.is_closed = true
 
-        $httpBackend.expectPOST('/case/reopen/501/').respond('')
+        $httpBackend.expectPOST('/case/reopen/501/', {note: "Hello there"}).respond('')
         CaseService.reopen(test.case1, "Hello there").then(() ->
           expect(test.case1.is_closed).toEqual(false)
         )
@@ -155,7 +155,7 @@ describe('services:', () ->
     
     describe('replyTo', () ->
       it('posts to reply endpoint', () ->
-        $httpBackend.expectPOST('/case/reply/501/').respond('')
+        $httpBackend.expectPOST('/case/reply/501/', {text: "Hello there"}).respond('')
         CaseService.replyTo(test.case1, "Hello there")
         $httpBackend.flush()
       )
@@ -163,7 +163,7 @@ describe('services:', () ->
 
     describe('startExport', () ->
       it('posts to export endpoint', () ->
-        $httpBackend.expectPOST('/caseexport/create/?folder=open').respond('')
+        $httpBackend.expectPOST('/caseexport/create/?folder=open', null).respond('')
         CaseService.startExport({folder: "open"})
         $httpBackend.flush()
       )
@@ -171,7 +171,7 @@ describe('services:', () ->
 
     describe('updateSummary', () ->
       it('posts to update summary endpoint', () ->
-        $httpBackend.expectPOST('/case/update_summary/501/').respond('')
+        $httpBackend.expectPOST('/case/update_summary/501/', {summary: "Got coffee?"}).respond('')
         CaseService.updateSummary(test.case1, "Got coffee?").then(() ->
           expect(test.case1.summary).toEqual("Got coffee?")
         )
@@ -192,7 +192,7 @@ describe('services:', () ->
 
     describe('delete', () ->
       it('posts to delete endpoint', () ->
-        $httpBackend.expectPOST('/label/delete/201/').respond("")
+        $httpBackend.expectPOST('/label/delete/201/', null).respond("")
         LabelService.delete(test.tea)
         $httpBackend.flush()
       )
@@ -235,7 +235,7 @@ describe('services:', () ->
 
     describe('bulkArchive', () ->
       it('posts to bulk action endpoint', () ->
-        $httpBackend.expectPOST('/message/action/archive/').respond('')
+        $httpBackend.expectPOST('/message/action/archive/', {messages: [101, 102]}).respond('')
         MessageService.bulkArchive([test.msg1, test.msg2]).then(() ->
           expect(test.msg1.archived).toEqual(true)
           expect(test.msg2.archived).toEqual(true)
@@ -246,14 +246,14 @@ describe('services:', () ->
 
     describe('bulkFlag', () ->
       it('posts to bulk action endpoint', () ->
-        $httpBackend.expectPOST('/message/action/flag/').respond('')
+        $httpBackend.expectPOST('/message/action/flag/', {messages: [101, 102]}).respond('')
         MessageService.bulkFlag([test.msg1, test.msg2], true).then(() ->
           expect(test.msg1.flagged).toEqual(true)
           expect(test.msg2.flagged).toEqual(true)
         )
         $httpBackend.flush()
 
-        $httpBackend.expectPOST('/message/action/unflag/').respond('')
+        $httpBackend.expectPOST('/message/action/unflag/', {messages: [101, 102]}).respond('')
         MessageService.bulkFlag([test.msg1, test.msg2], false).then(() ->
           expect(test.msg1.flagged).toEqual(false)
           expect(test.msg2.flagged).toEqual(false)
@@ -264,7 +264,7 @@ describe('services:', () ->
 
     describe('bulkLabel', () ->
       it('posts to bulk action endpoint', () ->
-        $httpBackend.expectPOST('/message/action/label/').respond('')
+        $httpBackend.expectPOST('/message/action/label/', {messages: [101, 102], label: 201}).respond('')
         MessageService.bulkLabel([test.msg1, test.msg2], test.tea).then(() ->
           expect(test.msg1.labels).toEqual([test.tea])
           expect(test.msg2.labels).toEqual([test.coffee, test.tea])
@@ -275,7 +275,7 @@ describe('services:', () ->
 
     describe('bulkReply', () ->
       it('posts to bulk reply endpoint', () ->
-        $httpBackend.expectPOST('/message/bulk_reply/').respond('')
+        $httpBackend.expectPOST('/message/bulk_reply/', {messages: [101, 102], text: "Welcome"}).respond('')
         MessageService.bulkReply([test.msg1, test.msg2], "Welcome")
         $httpBackend.flush()
       )
@@ -283,7 +283,7 @@ describe('services:', () ->
 
     describe('bulkRestore', () ->
       it('posts to bulk action endpoint', () ->
-        $httpBackend.expectPOST('/message/action/restore/').respond('')
+        $httpBackend.expectPOST('/message/action/restore/', {messages: [101, 102]}).respond('')
         MessageService.bulkRestore([test.msg1, test.msg2]).then(() ->
           expect(test.msg1.archived).toEqual(false)
           expect(test.msg2.archived).toEqual(false)
@@ -294,7 +294,7 @@ describe('services:', () ->
 
     describe('forward', () ->
       it('posts to forward endpoint', () ->
-        $httpBackend.expectPOST('/message/forward/101/').respond('')
+        $httpBackend.expectPOST('/message/forward/101/', {text: "Welcome", urns: ["tel:+260964153686"]}).respond('')
         MessageService.forward(test.msg1, "Welcome", {urn: "tel:+260964153686"})
         $httpBackend.flush()
       )
@@ -302,7 +302,7 @@ describe('services:', () ->
 
     describe('relabel', () ->
       it('posts to label endpoint', () ->
-        $httpBackend.expectPOST('/message/label/101/').respond('')
+        $httpBackend.expectPOST('/message/label/101/', {labels: [202]}).respond('')
         MessageService.relabel(test.msg1, [test.coffee]).then(() ->
           expect(test.msg1.labels).toEqual([test.coffee])
         )
@@ -312,7 +312,7 @@ describe('services:', () ->
 
     describe('startExport', () ->
       it('posts to export endpoint', () ->
-        $httpBackend.expectPOST('/messageexport/create/?archived=0&folder=inbox').respond('')
+        $httpBackend.expectPOST('/messageexport/create/?archived=0&folder=inbox', null).respond('')
         MessageService.startExport({folder: "inbox"})
         $httpBackend.flush()
       )
@@ -353,7 +353,7 @@ describe('services:', () ->
 
     describe('startReplyExport', () ->
       it('posts to export endpoint', () ->
-        $httpBackend.expectPOST('/replyexport/create/?partner=301').respond('')
+        $httpBackend.expectPOST('/replyexport/create/?partner=301', null).respond('')
         OutgoingService.startReplyExport({partner: test.moh})
         $httpBackend.flush()
       )
@@ -382,7 +382,7 @@ describe('services:', () ->
 
     describe('delete', () ->
       it('posts to delete endpoint', () ->
-        $httpBackend.expectPOST('/partner/delete/301/').respond('')
+        $httpBackend.expectPOST('/partner/delete/301/', null).respond('')
         PartnerService.delete(test.moh)
         $httpBackend.flush()
       )
@@ -401,7 +401,7 @@ describe('services:', () ->
 
     describe('delete', () ->
       it('posts to delete endpoint', () ->
-        $httpBackend.expectPOST('/user/delete/101/').respond('')
+        $httpBackend.expectPOST('/user/delete/101/', null).respond('')
         UserService.delete(test.user1)
         $httpBackend.flush()
       )

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -8,7 +8,7 @@ billiard==3.3.0.22
 boto==2.38.0
 celery==3.1.19
 coverage==4.0.3
--e git+https://github.com/rapidpro/dash.git@7f142d38858fd29d644750dbc369630d783a6037#egg=dash-master
+-e git+https://github.com/rapidpro/dash.git@f85f7e7262a62dfc385951ad3e0199434c7db9f0#egg=dash-master
 dj-database-url==0.3.0
 django-appconf==1.0.1
 django-celery==3.1.17


### PR DESCRIPTION
* Switches all service methods that post to endpoints to use JSON rather than `FormData`. This is the Angular default way and makes it simpler to test.
* Improves service method unit tests to check POST body