### PR TITLE
More frontend testing and cleanup

### DIFF
--- a/karma/helpers.coffee
+++ b/karma/helpers.coffee
@@ -1,4 +1,17 @@
-
+#
 # helper for creating UTC datetimes
+#
 utcdate = (y, m, d, h, min, sec, ms) ->
   return new Date(Date.UTC(y, m - 1, d, h, min, sec, ms))
+
+#
+# helper for mocking service methods that return a promise
+#
+spyOnPromise = ($q, scope, obj, method) ->
+  deferred = $q.defer()
+  spyOn(obj, method).and.returnValue(deferred.promise)
+  return {
+    resolve: (value) ->
+      deferred.resolve(value)
+      scope.$apply()
+  }

--- a/karma/helpers.coffee
+++ b/karma/helpers.coffee
@@ -5,13 +5,24 @@ utcdate = (y, m, d, h, min, sec, ms) ->
   return new Date(Date.UTC(y, m - 1, d, h, min, sec, ms))
 
 #
-# helper for mocking service methods that return a promise
+# helper for mocking service methods that return a promise, e.g.
 #
-spyOnPromise = ($q, scope, obj, method) ->
+# fetchBar = spyOnPromise($q, $scope, FooService, 'fetchBar')
+#
+# <do something which will wait for an fetchBar promise to be resolved>
+#
+# fetchBar.resolve("bar")
+#
+spyOnPromise = ($q, $scope, obj, method) ->
   deferred = $q.defer()
   spyOn(obj, method).and.returnValue(deferred.promise)
+
   return {
+    reset: () ->
+      deferred = $q.defer()
+      obj[method].and.returnValue(deferred.promise)
+
     resolve: (value) ->
       deferred.resolve(value)
-      scope.$apply()
+      $scope.$apply()
   }

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -1,35 +1,143 @@
 # Unit tests for our Angular controllers (controllers listed A-Z)
 
 describe('controllers:', () ->
-  $rootScope = null
+  $window = null
   $controller = null
+  $rootScope = null
+  $scope = null
+  $q = null
+  UtilsService = null
+  test = null
 
   beforeEach(() ->
     module('cases')
 
-    inject((_$rootScope_, _$controller_) ->
-      $rootScope = _$rootScope_
+    inject((_$window_, _$controller_, _$rootScope_, _$q_, _UtilsService_) ->
+      $window = _$window_
       $controller = _$controller_
+      $rootScope = _$rootScope_
+      $q = _$q_
+      UtilsService = _UtilsService_
     )
+
+    $scope = $rootScope.$new()  # each test gets a new scope
+    jasmine.clock().install()
+
+    test = {
+      # users
+      user1: {id: 101, name: "Tom McTest"},
+
+      # labels
+      tea: {id: 201, name: "Tea"},
+      coffee: {id: 202, name: "Coffee"},
+
+      # partners
+      moh: {id: 301, name: "MOH"},
+      who: {id: 302, name: "WHO"}
+    }
+  )
+
+  afterEach(() ->
+    jasmine.clock().uninstall()
   )
   
   describe('DateRangeController', () ->
     it('should not allow min to be greater than max', () ->
+      jasmine.clock().mockDate(utcdate(2016, 1, 1, 11, 0, 0, 0));  # now is Jan 1st 2016 11:00 UTC
+
+      $rootScope.range = {after: null, before: null}
       $scope = $rootScope.$new()
-      $scope.range = {after: null, before: null}
 
       $controller('DateRangeController', { $scope: $scope })
       $scope.init('range.after', 'range.before')
 
-      $scope.range.after = utcdate(2015, 1, 1, 10, 0, 0, 0)
+      expect($scope.afterOptions).toEqual({minDate: null, maxDate: utcdate(2016, 1, 1, 11, 0, 0, 0)})
+      expect($scope.beforeOptions).toEqual({minDate: null, maxDate: utcdate(2016, 1, 1, 11, 0, 0, 0)})
+
+      # after field is given a value
+      $rootScope.range.after = utcdate(2015, 6, 1, 0, 0, 0, 0)  # Jun 1st 2015
       $scope.$digest()
 
-      expect($scope.beforeOptions.minDate).toEqual(utcdate(2015, 1, 1, 10, 0, 0, 0))
+      # value should become the min for before field
+      expect($scope.beforeOptions).toEqual({minDate: utcdate(2015, 6, 1, 0, 0, 0, 0), maxDate: utcdate(2016, 1, 1, 11, 0, 0, 0)})
 
-      $scope.range.before = utcdate(2016, 1, 1, 10, 0, 0, 0)
+      # before field is given a value
+      $rootScope.range.before = utcdate(2015, 8, 1, 0, 0, 0, 0)  # Aug 1st 2015
       $scope.$digest()
 
-      expect($scope.afterOptions.maxDate).toEqual(utcdate(2016, 1, 1, 10, 0, 0, 0))
+      # value should become the max for after field
+      expect($scope.afterOptions).toEqual({minDate: null, maxDate: utcdate(2015, 8, 1, 0, 0, 0, 0)})
+    )
+  )
+
+  describe('PartnerController', () ->
+    PartnerService = null
+
+    beforeEach(inject((_PartnerService_) ->
+      PartnerService = _PartnerService_
+
+      $window.contextData = {partner: test.moh}
+      $controller('PartnerController', {$scope: $scope})
+    ))
+
+    it('onTabSelect', () ->
+      expect($scope.users).toEqual([])
+      expect($scope.usersFetched).toEqual(false)
+
+      fetchUsers = spyOnPromise($q, $scope, PartnerService, 'fetchUsers')
+
+      $scope.onTabSelect('users')
+
+      users = [{id: 101, name: "Tom McTicket", replies: {last_month: 5, this_month: 10, total: 20}}]
+      fetchUsers.resolve(users)
+
+      expect($scope.users).toEqual(users)
+      expect($scope.usersFetched).toEqual(true)
+
+      # select the users tab again
+      $scope.onTabSelect('users')
+
+      # users shouldn't be re-fetched
+      expect(PartnerService.fetchUsers.calls.count()).toEqual(1)
+    )
+
+    it('onDeletePartner', () ->
+      confirmModal = spyOnPromise($q, $scope, UtilsService, 'confirmModal')
+      deletePartner = spyOnPromise($q, $scope, PartnerService, 'delete')
+      spyOn(UtilsService, 'navigate')
+
+      $scope.onDeletePartner()
+
+      confirmModal.resolve()
+      deletePartner.resolve()
+
+      expect(PartnerService.delete).toHaveBeenCalledWith(test.moh)
+      expect(UtilsService.navigate).toHaveBeenCalledWith('/partner/')
+    )
+  )
+
+  describe('UserController', () ->
+    UserService = null
+
+    beforeEach(inject((_UserService_) ->
+      UserService = _UserService_
+
+      $window.contextData = {user: test.user1}
+      $controller('UserController', {$scope: $scope})
+    ))
+
+    it('onDeleteUser', () ->
+      confirmModal = spyOnPromise($q, $scope, UtilsService, 'confirmModal')
+      deleteUser = spyOnPromise($q, $scope, UserService, 'delete')
+      spyOn(UtilsService, 'navigateBack')
+
+      $scope.onDeleteUser()
+
+      confirmModal.resolve()
+      deleteUser.resolve()
+
+      expect(UserService.delete).toHaveBeenCalledWith(test.user1)
+      expect(UtilsService.navigateBack).toHaveBeenCalled()
     )
   )
 )

--- a/karma/test-filters.coffee
+++ b/karma/test-filters.coffee
@@ -9,6 +9,12 @@ describe('filters:', () ->
     inject((_$filter_) ->
       $filter = _$filter_
     )
+
+    jasmine.clock().install()
+  )
+
+  afterEach(() ->
+    jasmine.clock().uninstall()
   )
 
   describe('reverse', () ->
@@ -19,14 +25,14 @@ describe('filters:', () ->
   )
 
   describe('autodate', () ->
-    jasmine.clock().mockDate(new Date(2015, 0, 1));  # Jan 1 2015
-
     it('formats a date', () ->
+      jasmine.clock().mockDate(new Date(2015, 1, 1));  # Feb 1 2015
+      
       autodate = $filter('autodate')
-      expect(autodate(new Date(2015, 0, 1, 10, 0))).toEqual("10:00")  # same day
-      expect(autodate(new Date(2015, 1, 1, 10, 0))).toEqual("Feb 1")  # same year
-      expect(autodate(new Date(2014, 0, 1, 10, 0))).toEqual("Jan 1, 2014")
-      expect(autodate(new Date(2014, 11, 31, 10, 0))).toEqual("Dec 31, 2014")
+      expect(autodate(new Date(2015, 1, 1, 10, 0))).toEqual("10:00")  # same day
+      expect(autodate(new Date(2015, 2, 1, 11, 0))).toEqual("Mar 1")  # same year
+      expect(autodate(new Date(2014, 1, 1, 10, 0))).toEqual("Feb 1, 2014")  # year before
+      expect(autodate(new Date(2016, 1, 1, 10, 0))).toEqual("Feb 1, 2016")  # year after
     )
   )
 )

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -2,13 +2,15 @@
 
 describe('services:', () ->
   $httpBackend = null
+  $window = null
   test = null
 
   beforeEach(() ->
     module('cases')
 
-    inject((_$httpBackend_) ->
+    inject((_$httpBackend_, _$window_) ->
       $httpBackend = _$httpBackend_
+      $window = _$window_
     )
 
     test = {
@@ -404,6 +406,101 @@ describe('services:', () ->
         $httpBackend.expectPOST('/user/delete/101/', null).respond('')
         UserService.delete(test.user1)
         $httpBackend.flush()
+      )
+    )
+  )
+
+  #=======================================================================
+  # Tests for UtilsService
+  #=======================================================================
+  describe('UtilsService', () ->
+    UtilsService = null
+    $uibModal = null
+
+    beforeEach(inject((_UtilsService_, _$uibModal_) ->
+      UtilsService = _UtilsService_
+      $uibModal = _$uibModal_
+
+      spyOn($uibModal, 'open').and.callThrough()
+    ))
+
+    describe('navigate', () ->
+      it('changes location of $window', () ->
+        spyOn($window.location, 'replace')
+
+        UtilsService.navigate("http://example.com")
+
+        expect($window.location.replace).toHaveBeenCalledWith("http://example.com")
+      )
+    )
+    
+    describe('navigateBack', () ->
+      it('calls history.back', () ->
+        spyOn($window.history, 'back')
+
+        UtilsService.navigateBack()
+
+        expect($window.history.back).toHaveBeenCalled()
+      )
+    )
+
+    describe('confirmModal', () ->
+      it('opens confirm modal', () ->
+        UtilsService.confirmModal("OK?")
+
+        modalOptions = $uibModal.open.calls.mostRecent().args[0]
+        expect(modalOptions.templateUrl).toEqual('confirmModal.html')
+        expect(modalOptions.resolve.prompt()).toEqual("OK?")
+      )
+    )
+
+    describe('editModal', () ->
+      it('opens confirm modal', () ->
+        UtilsService.editModal("Edit", "this...", 100)
+
+        modalOptions = $uibModal.open.calls.mostRecent().args[0]
+        expect(modalOptions.templateUrl).toEqual('editModal.html')
+        expect(modalOptions.resolve.title()).toEqual("Edit")
+        expect(modalOptions.resolve.initial()).toEqual("this...")
+        expect(modalOptions.resolve.maxLength()).toEqual(100)
+      )
+    )
+
+    describe('assignModal', () ->
+      it('opens assign modal', () ->
+        UtilsService.assignModal("Assign", "this...", [test.moh, test.who])
+
+        modalOptions = $uibModal.open.calls.mostRecent().args[0]
+        expect(modalOptions.templateUrl).toEqual('assignModal.html')
+        expect(modalOptions.resolve.title()).toEqual("Assign")
+        expect(modalOptions.resolve.prompt()).toEqual("this...")
+        expect(modalOptions.resolve.partners()).toEqual([test.moh, test.who])
+      )
+    )
+
+    describe('noteModal', () ->
+      it('opens note modal', () ->
+        UtilsService.noteModal("Note", "this...", 'danger', 100)
+
+        modalOptions = $uibModal.open.calls.mostRecent().args[0]
+        expect(modalOptions.templateUrl).toEqual('noteModal.html')
+        expect(modalOptions.resolve.title()).toEqual("Note")
+        expect(modalOptions.resolve.prompt()).toEqual("this...")
+        expect(modalOptions.resolve.style()).toEqual('danger')
+        expect(modalOptions.resolve.maxLength()).toEqual(100)
+      )
+    )
+
+    describe('labelModal', () ->
+      it('opens label modal', () ->
+        UtilsService.labelModal("Label", "this...", [test.tea, test.coffee], [test.tea])
+
+        modalOptions = $uibModal.open.calls.mostRecent().args[0]
+        expect(modalOptions.templateUrl).toEqual('labelModal.html')
+        expect(modalOptions.resolve.title()).toEqual("Label")
+        expect(modalOptions.resolve.prompt()).toEqual("this...")
+        expect(modalOptions.resolve.labels()).toEqual([test.tea, test.coffee])
+        expect(modalOptions.resolve.initial()).toEqual([test.tea])
       )
     )
   )

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -54,16 +54,6 @@ describe('services:', () ->
       )
     )
 
-    describe('fetchNew', () ->
-      it('gets cases from search endpoint', () ->
-        $httpBackend.expectGET('/case/search/?folder=open').respond('{"results":[{"id":501,"opened_on":"2016-05-17T08:49:13.698864"}],"has_more":true}')
-        CaseService.fetchNew({folder: "open"}).then((data) ->
-          expect(data.results).toEqual([{id: 501, opened_on: utcdate(2016, 5, 17, 8, 49, 13, 698)}])
-        )
-        $httpBackend.flush()
-      )
-    )
-
     describe('fetchOld', () ->
       it('gets cases from search endpoint', () ->
         $httpBackend.expectGET('/case/search/?folder=open').respond('{"results":[{"id":501,"opened_on":"2016-05-17T08:49:13.698864"}],"has_more":true}')

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -63,7 +63,7 @@ controllers.controller 'HomeController', [ '$scope', '$window', '$location', 'La
     $scope.$broadcast('activeContactChange')
 
   $scope.onDeleteLabel = () ->
-    UtilsService.confirmModal('Delete the label <strong>' + $scope.activeLabel.name + '</strong>?', 'danger', () ->
+    UtilsService.confirmModal('Delete the label <strong>' + $scope.activeLabel.name + '</strong>?', 'danger').then(() ->
       LabelService.delete($scope.activeLabel).then(() ->
         $scope.labels = (l for l in $scope.labels when l.id != $scope.activeLabel.id)
         $scope.activateLabel(null)
@@ -229,7 +229,7 @@ controllers.controller 'MessagesController', [ '$scope', '$timeout', '$uibModal'
     $scope.advancedSearch = state
 
   $scope.onExportSearch = () ->
-    UtilsService.confirmModal("Export the current message search?", null, () ->
+    UtilsService.confirmModal("Export the current message search?").then(() ->
       MessageService.startExport($scope.activeSearch).then(() ->
         UtilsService.displayAlert('success', "Export initiated and will be sent to your email address when complete")
       )
@@ -246,14 +246,14 @@ controllers.controller 'MessagesController', [ '$scope', '$timeout', '$uibModal'
   #----------------------------------------------------------------------------
 
   $scope.onLabelSelection = (label) ->
-    UtilsService.confirmModal('Apply the label <strong>' + label.name + '</strong> to the selected messages?', null, () ->
+    UtilsService.confirmModal('Apply the label <strong>' + label.name + '</strong> to the selected messages?').then(() ->
       MessageService.bulkLabel($scope.selection, label).then(() ->
         $scope.updateItems()
       )
     )
 
   $scope.onFlagSelection = () ->
-    UtilsService.confirmModal('Flag the selected messages?', null, () ->
+    UtilsService.confirmModal('Flag the selected messages?').then(() ->
       MessageService.bulkFlag($scope.selection, true).then(() ->
         $scope.updateItems()
       )
@@ -271,14 +271,14 @@ controllers.controller 'MessagesController', [ '$scope', '$timeout', '$uibModal'
     )
 
   $scope.onArchiveSelection = () ->
-    UtilsService.confirmModal('Archive the selected messages? This will remove them from your inbox.', null, () ->
+    UtilsService.confirmModal('Archive the selected messages? This will remove them from your inbox.').then(() ->
       MessageService.bulkArchive($scope.selection).then(() ->
         $scope.updateItems()
       )
     )
 
   $scope.onRestoreSelection = () ->
-    UtilsService.confirmModal('Restore the selected messages? This will put them back in your inbox.', null, () ->
+    UtilsService.confirmModal('Restore the selected messages? This will put them back in your inbox.').then(() ->
       MessageService.bulkRestore($scope.selection).then(() ->
         $scope.updateItems()
       )
@@ -325,7 +325,7 @@ controllers.controller 'MessagesController', [ '$scope', '$timeout', '$uibModal'
     )
 
   $scope.onLabelMessage = (message) ->
-    UtilsService.labelModal("Labels", "Update the labels for this message. This determines which other partner organizations can view this message.", $scope.labels, message.labels, (selectedLabels) ->
+    UtilsService.labelModal("Labels", "Update the labels for this message. This determines which other partner organizations can view this message.", $scope.labels, message.labels).then((selectedLabels) ->
       MessageService.relabel(message, selectedLabels).then(() ->
         $scope.updateItems()
       )
@@ -398,7 +398,7 @@ controllers.controller('CasesController', [ '$scope', '$timeout', '$controller',
   $scope.searchFieldDefaults = () -> { assignee: $scope.user.partner }
 
   $scope.onExportSearch = () ->
-    UtilsService.confirmModal("Export the current case search?", null, () ->
+    UtilsService.confirmModal("Export the current case search?").then(() ->
       CaseService.startExport($scope.activeSearch).then(() ->
         UtilsService.displayAlert('success', "Export initiated and will be sent to your email address when complete")
       )
@@ -451,14 +451,14 @@ controllers.controller 'CaseController', [ '$scope', '$window', '$timeout', 'Cas
     )
 
   $scope.onEditLabels = ->
-    UtilsService.labelModal("Labels", "Update the labels for this case. This determines which other partner organizations can view this case.", $scope.allLabels, $scope.caseObj.labels, (selectedLabels) ->
+    UtilsService.labelModal("Labels", "Update the labels for this case. This determines which other partner organizations can view this case.", $scope.allLabels, $scope.caseObj.labels).then((selectedLabels) ->
       CaseService.relabel($scope.caseObj, selectedLabels).then(() ->
         $scope.$broadcast('timelineChanged')
       )
     )
 
   $scope.onEditSummary = ->
-    UtilsService.editModal("Edit Summary", $scope.caseObj.summary, CASE_SUMMARY_MAX_LEN, (text) ->
+    UtilsService.editModal("Edit Summary", $scope.caseObj.summary, CASE_SUMMARY_MAX_LEN).then((text) ->
       CaseService.updateSummary($scope.caseObj, text).then(() ->
         $scope.$broadcast('timelineChanged')
       )
@@ -488,28 +488,28 @@ controllers.controller 'CaseController', [ '$scope', '$window', '$timeout', 'Cas
   #----------------------------------------------------------------------------
 
   $scope.onAddNote = () ->
-    UtilsService.noteModal("Add Note", null, null, CASE_NOTE_MAX_LEN, (note) ->
+    UtilsService.noteModal("Add Note", null, null, CASE_NOTE_MAX_LEN).then((note) ->
       CaseService.addNote($scope.caseObj, note).then(() ->
         $scope.$broadcast('timelineChanged')
       )
     )
 
   $scope.onReassign = () ->
-    UtilsService.assignModal("Re-assign", null, $scope.allPartners, (assignee) ->
+    UtilsService.assignModal("Re-assign", null, $scope.allPartners).then((assignee) ->
       CaseService.reassign($scope.caseObj, assignee).then(() ->
         $scope.$broadcast('timelineChanged')
       )
     )
 
   $scope.onClose = () ->
-    UtilsService.noteModal("Close", "Close this case?", 'danger', CASE_NOTE_MAX_LEN, (note) ->
+    UtilsService.noteModal("Close", "Close this case?", 'danger', CASE_NOTE_MAX_LEN).then((note) ->
       CaseService.close($scope.caseObj, note).then(() ->
         UtilsService.navigate('/')
       )
     )
 
   $scope.onReopen = () ->
-    UtilsService.noteModal("Re-open", "Re-open this case?", null, CASE_NOTE_MAX_LEN, (note) ->
+    UtilsService.noteModal("Re-open", "Re-open this case?", null, CASE_NOTE_MAX_LEN).then((note) ->
       CaseService.reopen($scope.caseObj, note).then(() ->
         $scope.$broadcast('timelineChanged')
       )
@@ -561,7 +561,7 @@ controllers.controller 'PartnerController', [ '$scope', '$window', 'UtilsService
       )
 
   $scope.onDeletePartner = () ->
-    UtilsService.confirmModal("Remove this partner organization?", 'danger', () ->
+    UtilsService.confirmModal("Remove this partner organization?", 'danger').then(() ->
       PartnerService.delete($scope.partner).then(() ->
         UtilsService.navigate('/partner/')
       )
@@ -600,7 +600,7 @@ controllers.controller 'PartnerRepliesController', [ '$scope', '$window', '$cont
     return OutgoingService.fetchReplies(search, startTime, page)
 
   $scope.onExportSearch = () ->
-    UtilsService.confirmModal("Export the current search?", null, () ->
+    UtilsService.confirmModal("Export the current search?").then(() ->
       OutgoingService.startReplyExport($scope.activeSearch).then(() ->
         UtilsService.displayAlert('success', "Export initiated and will be sent to your email address when complete")
       )
@@ -616,7 +616,7 @@ controllers.controller 'UserController', [ '$scope', '$window', 'UtilsService', 
   $scope.user = $window.contextData.user
 
   $scope.onDeleteUser = () ->
-    UtilsService.confirmModal("Delete this user?", 'danger', () ->
+    UtilsService.confirmModal("Delete this user?", 'danger').then(() ->
       UserService.delete($scope.user).then(() ->
         UtilsService.navigateBack()
       )

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -406,41 +406,28 @@ services.factory 'UtilsService', ['$window', '$uibModal', ($window, $uibModal) -
       $window.displayAlert(type, message)
 
     navigate: (url) ->
-      $window.location.href = url
+      $window.location.replace(url)
 
     navigateBack: () ->
       $window.history.back();
 
-    refresh: () ->
-      @navigate($window.location.href)
-
-    confirmModal: (prompt, style, callback) ->
+    confirmModal: (prompt, style) ->
       resolve = {prompt: (() -> prompt), style: (() -> style)}
-      $uibModal.open({templateUrl: 'confirmModal.html', controller: 'ConfirmModalController', resolve: resolve})
-      .result.then () ->
-        callback()
+      return $uibModal.open({templateUrl: 'confirmModal.html', controller: 'ConfirmModalController', resolve: resolve}).result
 
-    editModal: (title, initial, maxLength, callback) ->
+    editModal: (title, initial, maxLength) ->
       resolve = {title: (() -> title), initial: (() -> initial), maxLength: (() -> maxLength)}
-      $uibModal.open({templateUrl: 'editModal.html', controller: 'EditModalController', resolve: resolve})
-      .result.then (text) ->
-        callback(text)
+      return $uibModal.open({templateUrl: 'editModal.html', controller: 'EditModalController', resolve: resolve}).result
 
-    assignModal: (title, prompt, partners, callback) ->
+    assignModal: (title, prompt, partners) ->
       resolve = {title: (() -> title), prompt: (() -> prompt), partners: (() -> partners)}
-      $uibModal.open({templateUrl: 'assignModal.html', controller: 'AssignModalController', resolve: resolve})
-      .result.then (assignee) ->
-        callback(assignee)
+      return $uibModal.open({templateUrl: 'assignModal.html', controller: 'AssignModalController', resolve: resolve}).result
 
-    noteModal: (title, prompt, style, maxLength, callback) ->
+    noteModal: (title, prompt, style, maxLength) ->
       resolve = {title: (() -> title), prompt: (() -> prompt), style: (() -> style), maxLength: (() -> maxLength)}
-      $uibModal.open({templateUrl: 'noteModal.html', controller: 'NoteModalController', resolve: resolve})
-      .result.then (note) ->
-        callback(note)
+      return $uibModal.open({templateUrl: 'noteModal.html', controller: 'NoteModalController', resolve: resolve}).result
 
-    labelModal: (title, prompt, labels, initial, callback) ->
+    labelModal: (title, prompt, labels, initial) ->
       resolve = {title: (() -> title), prompt: (() -> prompt), labels: (() -> labels), initial: (() -> initial)}
-      $uibModal.open({templateUrl: 'labelModal.html', controller: 'LabelModalController', resolve: resolve})
-      .result.then (selectedLabels) ->
-        callback(selectedLabels)
+      return $uibModal.open({templateUrl: 'labelModal.html', controller: 'LabelModalController', resolve: resolve}).result
 ]

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -9,7 +9,7 @@ services = angular.module('cases.services', ['cases.modals']);
 # Incoming message service
 #=====================================================================
 
-services.factory 'MessageService', ['$rootScope', '$http', '$httpParamSerializer', ($rootScope, $http, $httpParamSerializer) ->
+services.factory('MessageService', ['$rootScope', '$http', '$httpParamSerializer', ($rootScope, $http, $httpParamSerializer) ->
   new class MessageService
 
     #----------------------------------------------------------------------------
@@ -129,14 +129,14 @@ services.factory 'MessageService', ['$rootScope', '$http', '$httpParamSerializer
         params.label = label.id
 
       return $http.post('/message/action/' + action + '/', params)
-]
+])
 
 
 #=====================================================================
 # Incoming message service
 #=====================================================================
 
-services.factory 'OutgoingService', ['$rootScope', '$http', '$httpParamSerializer', ($rootScope, $http, $httpParamSerializer) ->
+services.factory('OutgoingService', ['$rootScope', '$http', '$httpParamSerializer', ($rootScope, $http, $httpParamSerializer) ->
   new class OutgoingService
 
     #----------------------------------------------------------------------------
@@ -183,14 +183,14 @@ services.factory 'OutgoingService', ['$rootScope', '$http', '$httpParamSerialize
         before: if search.before then utils.formatIso8601(search.before) else utils.formatIso8601(startTime),
         page: page
       }
-]
+])
 
 
 #=====================================================================
 # Case service
 #=====================================================================
 
-services.factory 'CaseService', ['$http', '$httpParamSerializer', '$window', ($http, $httpParamSerializer, $window) ->
+services.factory('CaseService', ['$http', '$httpParamSerializer', '$window', ($http, $httpParamSerializer, $window) ->
   new class CaseService
 
     #----------------------------------------------------------------------------
@@ -204,19 +204,6 @@ services.factory 'CaseService', ['$http', '$httpParamSerializer', '$window', ($h
       return $http.get('/case/search/?' + $httpParamSerializer(params)).then((response) ->
         utils.parseDates(response.data.results, 'opened_on')
         return {results: response.data.results, hasMore: response.data.has_more}
-      )
-
-    #----------------------------------------------------------------------------
-    # Fetches new cases
-    #----------------------------------------------------------------------------
-    fetchNew: (search, after, before) ->
-      params = @_searchToParams(search)
-      params.after = utils.formatIso8601(after)
-      params.before = utils.formatIso8601(before)
-
-      return $http.get('/case/search/?' + $httpParamSerializer(params)).then((response) ->
-        utils.parseDates(response.data.results, 'opened_on')
-        return {results: response.data.results}
       )
 
     #----------------------------------------------------------------------------
@@ -343,14 +330,14 @@ services.factory 'CaseService', ['$http', '$httpParamSerializer', '$window', ($h
         assignee: if search.assignee then search.assignee.id else null,
         label: if search.label then search.label.id else null
       }
-]
+])
 
 
 #=====================================================================
 # Label service
 #=====================================================================
 
-services.factory 'LabelService', ['$http', ($http) ->
+services.factory('LabelService', ['$http', ($http) ->
   new class LabelService
 
     #----------------------------------------------------------------------------
@@ -358,13 +345,13 @@ services.factory 'LabelService', ['$http', ($http) ->
     #----------------------------------------------------------------------------
     delete: (label) ->
       return $http.post('/label/delete/' + label.id + '/')
-]
+])
 
 
 #=====================================================================
 # Partner service
 #=====================================================================
-services.factory 'PartnerService', ['$http', ($http) ->
+services.factory('PartnerService', ['$http', ($http) ->
   new class PartnerService
 
     #----------------------------------------------------------------------------
@@ -378,13 +365,13 @@ services.factory 'PartnerService', ['$http', ($http) ->
     #----------------------------------------------------------------------------
     delete: (partner) ->
       return $http.post('/partner/delete/' + partner.id + '/')
-]
+])
 
 
 #=====================================================================
 # User service
 #=====================================================================
-services.factory 'UserService', ['$http', ($http) ->
+services.factory('UserService', ['$http', ($http) ->
   new class UserService
 
     #----------------------------------------------------------------------------
@@ -392,17 +379,16 @@ services.factory 'UserService', ['$http', ($http) ->
     #----------------------------------------------------------------------------
     delete: (user) ->
       return $http.post('/user/delete/' + user.id + '/')
-]
+])
 
 
 #=====================================================================
 # Utils service
 #=====================================================================
-services.factory 'UtilsService', ['$window', '$uibModal', ($window, $uibModal) ->
+services.factory('UtilsService', ['$window', '$uibModal', ($window, $uibModal) ->
   new class UtilsService
 
     displayAlert: (type, message) ->
-      # TODO angularize ?
       $window.displayAlert(type, message)
 
     navigate: (url) ->
@@ -430,4 +416,4 @@ services.factory 'UtilsService', ['$window', '$uibModal', ($window, $uibModal) -
     labelModal: (title, prompt, labels, initial) ->
       resolve = {title: (() -> title), prompt: (() -> prompt), labels: (() -> labels), initial: (() -> initial)}
       return $uibModal.open({templateUrl: 'labelModal.html', controller: 'LabelModalController', resolve: resolve}).result
-]
+])

--- a/templates/cases/home_base.haml
+++ b/templates/cases/home_base.haml
@@ -16,7 +16,7 @@
   %script{ type:"text/javascript" }
     var contextData = {{ context_data_json|safe }};
 
-  .ng-cloak{ ng-controller:"HomeController", ng-init:'init("{{ folder }}")', ng-cloak:"" }
+  .ng-cloak{ ng-controller:"HomeController", ng-init:'init("{{ folder }}", {{ server_time }})', ng-cloak:"" }
     .page-header.clearfix
       %h2.pull-back
         %span{ class:'glyphicon {{ folder_icon }}' }


### PR DESCRIPTION
 * all modal creating service methods now return promises rather than taking callbacks
 * server time now used for start point of item fetches
 * removed new item fetching code for cases - current implementation relies on browser time and so isn't reliable. Need to figure out mechanism for new item fetching that will work for messages and cases.
 * changed `BaseItemsController` to only load old items if active label actually changes - means item fetching is started by the `infinite-scroll` directive on the page rather than from controller initialisation
 * consistent use of parentheses for coffeescript function calls
 * more frontend test coverage