### PR TITLE
Don't delete users, just remove them from orgs

### DIFF
--- a/casepro/profiles/__init__.py
+++ b/casepro/profiles/__init__.py
@@ -123,9 +123,16 @@ def _user_can_edit(user, org, other):
     return other_partner and user.can_manage(other_partner)  # manager can edit users in same partner org
 
 
-def _user_release(user):
-    user.is_active = False
-    user.save(update_fields=('is_active',))
+def _user_remove_from_org(user, org):
+    # remove user from all org groups
+    org.administrators.remove(user)
+    org.editors.remove(user)
+    org.viewers.remove(user)
+
+    # remove from any partner for this org
+    if user.profile.partner and user.profile.partner.org == org:
+        user.profile.partner = None
+        user.profile.save(update_fields=('partner',))
 
 
 def _user_unicode(user):
@@ -151,6 +158,6 @@ User.get_partner = _user_get_partner
 User.can_administer = _user_can_administer
 User.can_manage = _user_can_manage
 User.can_edit = _user_can_edit
-User.release = _user_release
+User.remove_from_org = _user_remove_from_org
 User.__unicode__ = _user_unicode
 User.as_json = _user_as_json

--- a/casepro/profiles/migrations/0004_fix_deleted_users.py
+++ b/casepro/profiles/migrations/0004_fix_deleted_users.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def fix_deleted_users(apps, schema_editor):
+    """
+    Previously deleting users from orgs caused them to be set as inactive, which then causes difficulties if someone
+    tries to re-add that user to an org. This re-activates deleted users and instead removes them from org groups.
+    """
+    Org = apps.get_model('orgs', 'Org')
+    User = apps.get_model('auth', 'User')
+
+    all_orgs = Org.objects.all()
+    inactive_users = list(User.objects.filter(is_active=False))
+
+    for user in inactive_users:
+        # remove user from all org groups
+        for org in all_orgs:
+            org.administrators.remove(user)
+            org.editors.remove(user)
+            org.viewers.remove(user)
+
+        # remove from any partner for this org
+        if user.profile.partner:
+            user.profile.partner = None
+            user.profile.save(update_fields=('partner',))
+
+        # re-activate user
+        user.is_active = True
+        user.save(update_fields=('is_active',))
+
+    if inactive_users:
+        print("Fixed %d inactive users" % len(inactive_users))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0003_username_max_length'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_deleted_users)
+    ]

--- a/casepro/profiles/views.py
+++ b/casepro/profiles/views.py
@@ -230,11 +230,13 @@ class UserCRUDL(SmartCRUDL):
         cancel_url = '@profiles.user_list'
 
         def has_permission(self, request, *args, **kwargs):
-            return request.user.can_edit(request.org, self.get_object())
+            user = self.get_object()
+            return request.user.can_edit(request.org, user) and request.user != user
 
         def post(self, request, *args, **kwargs):
             user = self.get_object()
-            user.release()
+            user.remove_from_org(request.org)
+
             return HttpResponse(status=204)
 
     class List(OrgPermsMixin, UserFieldsMixin, SmartListView):


### PR DESCRIPTION
So that it's easier to put them back in that org or other orgs. Includes migration to reactivate deleted users but remove them from all orgs.