### PR TITLE
Allow admin users to create other admin users and add password complexity checks

### DIFF
--- a/casepro/cases/mixins.py
+++ b/casepro/cases/mixins.py
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+
+from dash.orgs.views import OrgPermsMixin
+
+
+class PartnerPermsMixin(OrgPermsMixin):
+    """
+    Permissions mixin that requires users to have the view specific permission AND either be in the same partner org,
+    or not be attached to a partner.
+    """
+    def has_permission(self, request, *args, **kwargs):
+        if not super(PartnerPermsMixin, self).has_permission(request, *args, **kwargs):
+            return False
+
+        user_partner = self.request.user.get_partner(self.request.org)
+        return not user_partner or user_partner == self.get_partner()

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -18,7 +18,7 @@ from xlrd import open_workbook
 from casepro.contacts.models import Contact
 from casepro.msgs.models import Message, Outgoing
 from casepro.msgs.tasks import handle_messages
-from casepro.profiles import ROLE_ANALYST, ROLE_MANAGER
+from casepro.profiles.models import ROLE_ANALYST, ROLE_MANAGER
 from casepro.test import BaseCasesTest
 from casepro.utils import datetime_to_microseconds, microseconds_to_datetime
 

--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -373,7 +373,7 @@ class PartnerCRUDL(SmartCRUDL):
         def get_queryset(self, **kwargs):
             return Partner.get_all(self.request.org).order_by('name')
 
-    class Users(OrgPermsMixin, SmartReadView):
+    class Users(OrgObjPermsMixin, SmartReadView):
         """
         JSON endpoint to fetch partner users with their activity information
         """

--- a/casepro/orgs_ext/__init__.py
+++ b/casepro/orgs_ext/__init__.py
@@ -1,10 +1,17 @@
 from __future__ import absolute_import, unicode_literals
 
 from dash.orgs.models import Org
+from django.contrib.auth.models import User
+from django.db.models import Q
 
 
 ORG_CACHE_TTL = 60 * 60 * 24 * 7  # 1 week
 ORG_CONFIG_BANNER_TEXT = 'banner_text'
+
+
+def _org_get_users(org):
+    queryset = User.objects.filter(is_active=True)
+    return queryset.filter(Q(org_admins=org) | Q(org_editors=org) | Q(org_viewers=org)).distinct()
 
 
 def _org_get_banner_text(org):
@@ -15,5 +22,6 @@ def _org_set_banner_text(org, text):
     org.set_config(ORG_CONFIG_BANNER_TEXT, text)
 
 
+Org.get_users = _org_get_users
 Org.get_banner_text = _org_get_banner_text
 Org.set_banner_text = _org_set_banner_text

--- a/casepro/orgs_ext/mixins.py
+++ b/casepro/orgs_ext/mixins.py
@@ -9,4 +9,3 @@ class OrgFormMixin(object):
         kwargs = super(OrgFormMixin, self).get_form_kwargs()
         kwargs['org'] = self.request.org
         return kwargs
-

--- a/casepro/orgs_ext/mixins.py
+++ b/casepro/orgs_ext/mixins.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+
+
+class OrgFormMixin(object):
+    """
+    Mixin for views that need to pass org to their form
+    """
+    def get_form_kwargs(self):
+        kwargs = super(OrgFormMixin, self).get_form_kwargs()
+        kwargs['org'] = self.request.org
+        return kwargs
+

--- a/casepro/profiles/forms.py
+++ b/casepro/profiles/forms.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from casepro.cases.models import Partner
 
-from . import ROLE_ANALYST, ROLE_CHOICES
+from .models import ROLE_ANALYST, ROLE_PARTNER_CHOICES
 
 
 class UserForm(forms.ModelForm):
@@ -16,9 +16,9 @@ class UserForm(forms.ModelForm):
     """
     full_name = forms.CharField(label=_("Full name"), max_length=128)
 
-    partner = forms.ModelChoiceField(label=_("Partner Organization"), queryset=Partner.objects.none())
+    role = forms.ChoiceField(label=_("Role"), choices=ROLE_PARTNER_CHOICES, required=True, initial=ROLE_ANALYST)
 
-    role = forms.ChoiceField(label=_("Role"), choices=ROLE_CHOICES, required=True, initial=ROLE_ANALYST)
+    partner = forms.ModelChoiceField(label=_("Partner Organization"), queryset=Partner.objects.none())
 
     email = forms.CharField(label=_("Email"), max_length=254,
                             help_text=_("Email address and login."))
@@ -40,7 +40,7 @@ class UserForm(forms.ModelForm):
 
         super(UserForm, self).__init__(*args, **kwargs)
 
-        self.fields['partner'].queryset = Partner.get_all(self.org)
+        self.fields['partner'].queryset = Partner.get_all(self.org).order_by('name')
 
     def clean(self):
         cleaned_data = super(UserForm, self).clean()

--- a/casepro/profiles/forms.py
+++ b/casepro/profiles/forms.py
@@ -4,7 +4,6 @@ from django import forms
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
-from smartmin.users.models import is_password_complex
 
 from casepro.cases.models import Partner
 
@@ -16,9 +15,11 @@ class PasswordValidator(object):
     Basic password complexity check - should integrate with auth's validate_password functionality when we update to
     Django 1.9.
     """
+    MIN_LENGTH = 10
+
     def __call__(self, value):
-        if not is_password_complex(value):
-            raise ValidationError(_("Must contain a mixture of lowercase and uppercase, as well as a number"))
+        if len(value) < self.MIN_LENGTH:
+            raise ValidationError(_("Must be at least %d characters long") % self.MIN_LENGTH)
 
 
 class UserForm(forms.ModelForm):

--- a/casepro/profiles/models.py
+++ b/casepro/profiles/models.py
@@ -6,6 +6,11 @@ from django.utils.translation import ugettext_lazy as _
 
 from casepro.cases.models import Partner
 
+ROLE_ADMIN = 'A'
+ROLE_MANAGER = 'M'
+ROLE_ANALYST = 'Y'
+ROLE_PARTNER_CHOICES = ((ROLE_ANALYST, _("Data Analyst")), (ROLE_MANAGER, _("Manager")))
+
 
 class Profile(models.Model):
     """
@@ -18,3 +23,68 @@ class Profile(models.Model):
     full_name = models.CharField(verbose_name=_("Full name"), max_length=128, null=True)
 
     change_password = models.BooleanField(default=False, help_text=_("User must change password on next login"))
+
+    @classmethod
+    def create_user(cls, name, email, password, change_password=False):
+        """
+        Creates an un-attached user
+        """
+        # create auth user
+        user = User.objects.create(username=email, email=email, is_active=True)
+        user.set_password(password)
+        user.save()
+
+        # add profile
+        cls.objects.create(user=user, full_name=name, change_password=change_password)
+
+        return user
+
+    @classmethod
+    def create_org_user(cls, org, name, email, password, change_password=False):
+        """
+        Creates an org-level user (for now these are always admins)
+        """
+        user = cls.create_user(name, email, password, change_password=change_password)
+        user.profile.update_role(org, ROLE_ADMIN)
+        return user
+
+    @classmethod
+    def create_partner_user(cls, org, partner, role, name, email, password, change_password=False):
+        """
+        Creates a partner-level user
+        """
+        if not partner or partner.org != org:  # pragma: no cover
+            raise ValueError("Can't create partner user without valid partner for org")
+
+        user = cls.create_user(name, email, password, change_password=change_password)
+        user.profile.update_role(org, role, partner)
+        return user
+
+    def update_role(self, org, role, partner=None):
+        if partner and partner.org != org:  # pragma: no cover
+            raise ValueError("Can only update partner to partner in same org")
+
+        self.partner = partner
+        self.save(update_fields=('partner',))
+
+        if role == ROLE_ADMIN:
+            org.administrators.add(self.user)
+            org.editors.remove(self.user)
+            org.viewers.remove(self.user)
+        elif role == ROLE_MANAGER:
+            org.administrators.remove(self.user)
+            org.editors.add(self.user)
+            org.viewers.remove(self.user)
+        elif role == ROLE_ANALYST:
+            org.administrators.remove(self.user)
+            org.editors.remove(self.user)
+            org.viewers.add(self.user)
+        else:  # pragma: no cover
+            raise ValueError("Invalid user role: %s" % role)
+
+    @classmethod
+    def exists_for(cls, user):
+        try:
+            return bool(user.profile)
+        except Profile.DoesNotExist:
+            return False

--- a/casepro/profiles/tests.py
+++ b/casepro/profiles/tests.py
@@ -326,6 +326,17 @@ class UserCRUDLTest(BaseCasesTest):
         user = User.objects.get(email='bob@moh.com')
         self.assertEqual(user.profile.partner, self.moh)  # WHO was ignored
 
+        # partner managers can't access page for other partner orgs
+        url = reverse('profiles.user_create_in', args=[self.who.pk])
+        response = self.url_post('unicef', url)
+        self.assertLoginRedirect(response, 'unicef', url)
+
+        # partner analysts can't access page at all
+        self.login(self.user2)
+        url = reverse('profiles.user_create_in', args=[self.moh.pk])
+        response = self.url_post('unicef', url)
+        self.assertLoginRedirect(response, 'unicef', url)
+
     def test_update(self):
         url = reverse('profiles.user_update', args=[self.user2.pk])
 

--- a/casepro/profiles/tests.py
+++ b/casepro/profiles/tests.py
@@ -186,7 +186,7 @@ class UserCRUDLTest(BaseCasesTest):
 
         # submit again with all required fields to create an un-attached user
         response = self.url_post(None, url, {'name': "McAdmin", 'email': "mcadmin@casely.com",
-                                             'password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                             'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, 'http://testserver/user/')
 
@@ -215,7 +215,7 @@ class UserCRUDLTest(BaseCasesTest):
         # create another org admin user
         response = self.url_post('unicef', url, {'name': "Adrian Admin", 'email': "adrian@casely.com",
                                                  'role': ROLE_ADMIN,
-                                                 'password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, 'http://unicef.localhost/user/')
 
@@ -228,26 +228,25 @@ class UserCRUDLTest(BaseCasesTest):
         # submit again without providing a partner for role that requires one
         response = self.url_post('unicef', url, {'name': "Mo Cases", 'email': "mo@casely.com",
                                                  'partner': None, 'role': ROLE_ANALYST,
-                                                 'password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertFormError(response, 'form', 'partner', "Required for role.")
 
         # submit again with all required fields but invalid password
         response = self.url_post('unicef', url, {'name': "Mo Cases", 'email': "mo@casely.com",
                                                  'partner': self.moh.pk, 'role': ROLE_ANALYST,
                                                  'password': "123", 'confirm_password': "123"})
-        self.assertFormError(response, 'form', 'password', "Must contain a mixture of lowercase and uppercase, "
-                                                           "as well as a number")
+        self.assertFormError(response, 'form', 'password', "Must be at least 10 characters long")
 
         # submit again with valid password but mismatched confirmation
         response = self.url_post('unicef', url, {'name': "Mo Cases", 'email': "mo@casely.com",
                                                  'partner': self.moh.pk, 'role': ROLE_ANALYST,
-                                                 'password': "Qwerty123", 'confirm_password': "Azerty234"})
+                                                 'password': "Qwerty12345", 'confirm_password': "Azerty23456"})
         self.assertFormError(response, 'form', 'confirm_password', "Passwords don't match.")
 
         # submit again with valid password and confirmation
         response = self.url_post('unicef', url, {'name': "Mo Cases", 'email': "mo@casely.com",
                                                  'partner': self.moh.pk, 'role': ROLE_ANALYST,
-                                                 'password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, 'http://unicef.localhost/user/')
 
@@ -261,7 +260,7 @@ class UserCRUDLTest(BaseCasesTest):
 
         # try again with same email address
         response = self.url_post('unicef', url, {'name': "Mo Cases II", 'email': "mo@casely.com",
-                                                 'password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertFormError(response, 'form', None, "Email address already taken.")
 
         # log in as a partner manager
@@ -287,7 +286,7 @@ class UserCRUDLTest(BaseCasesTest):
 
         # submit again with all required fields
         response = self.url_post('unicef', url, {'name': "Mo Cases", 'email': "mo@casely.com", 'role': ROLE_ANALYST,
-                                                 'password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, 'http://unicef.localhost/partner/read/%d/' % self.moh.pk)
 
@@ -307,7 +306,7 @@ class UserCRUDLTest(BaseCasesTest):
 
         # submit again with all required fields to create another manager
         response = self.url_post('unicef', url, {'name': "McManage", 'email': "manager@moh.com", 'role': ROLE_MANAGER,
-                                                 'password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
 
         user = User.objects.get(email='manager@moh.com')
@@ -320,7 +319,7 @@ class UserCRUDLTest(BaseCasesTest):
         # submit again with partner - not allowed and will be ignored
         response = self.url_post('unicef', url, {'name': "Bob", 'email': "bob@moh.com",
                                                  'partner': self.who, 'role': ROLE_MANAGER,
-                                                 'password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
 
         user = User.objects.get(email='bob@moh.com')
@@ -396,13 +395,12 @@ class UserCRUDLTest(BaseCasesTest):
         response = self.url_post('unicef', url, {'name': "Bill", 'email': "bill@unicef.org",
                                                  'partner': self.moh.pk, 'role': ROLE_MANAGER,
                                                  'new_password': "123", 'confirm_password': "123"})
-        self.assertFormError(response, 'form', 'new_password', "Must contain a mixture of lowercase and uppercase, "
-                                                               "as well as a number")
+        self.assertFormError(response, 'form', 'new_password', "Must be at least 10 characters long")
 
         # submit with old email, valid password, and switch back to being analyst for MOH
         response = self.url_post('unicef', url, {'name': "Bill", 'email': "bill@unicef.org",
                                                  'partner': self.moh.pk, 'role': ROLE_ANALYST,
-                                                 'new_password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'new_password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
         self.user2.refresh_from_db()
         self.user2.profile.refresh_from_db()
@@ -429,7 +427,7 @@ class UserCRUDLTest(BaseCasesTest):
 
         # update partner colleague
         response = self.url_post('unicef', url, {'name': "Bob", 'email': "bob@unicef.org", 'role': ROLE_MANAGER,
-                                                 'new_password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'new_password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
         self.user2.refresh_from_db()
         self.user2.profile.refresh_from_db()
@@ -445,7 +443,7 @@ class UserCRUDLTest(BaseCasesTest):
         self.assertEqual(self.url_get('unicef', url).status_code, 302)
 
         # partner analyst users can't access page
-        self.client.login(username="bill@unicef.org", password="Qwerty123")
+        self.client.login(username="bill@unicef.org", password="Qwerty12345")
         self.assertEqual(self.url_get('unicef', url).status_code, 302)
 
     def test_read(self):
@@ -581,13 +579,12 @@ class UserCRUDLTest(BaseCasesTest):
         # submit with too simple a password
         response = self.url_post('unicef', url, {'name': "Morris", 'email': "mo2@trac.com",
                                                  'new_password': "123", 'confirm_password': "123"})
-        self.assertFormError(response, 'form', 'new_password', "Must contain a mixture of lowercase and uppercase, "
-                                                               "as well as a number")
+        self.assertFormError(response, 'form', 'new_password', "Must be at least 10 characters long")
 
         # submit with all required fields entered and valid password fields
         old_password_hash = user.password
         response = self.url_post('unicef', url, {'name': "Morris", 'email': "mo2@trac.com",
-                                                 'new_password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'new_password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
 
         # check password has been changed
@@ -606,13 +603,13 @@ class UserCRUDLTest(BaseCasesTest):
 
         # submit again with new password but no confirmation
         response = self.url_post('unicef', url, {'name': "Morris", 'email': "mo2@trac.com",
-                                                 'new_password': "Qwerty123"})
+                                                 'new_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 200)
         self.assertFormError(response, 'form', 'confirm_password', "Passwords don't match.")
 
         # submit again with new password and confirmation
         response = self.url_post('unicef', url, {'name': "Morris", 'email': "mo2@trac.com",
-                                                 'new_password': "Qwerty123", 'confirm_password': "Qwerty123"})
+                                                 'new_password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
 
         # check password has changed and no longer has to be changed

--- a/casepro/profiles/urls.py
+++ b/casepro/profiles/urls.py
@@ -1,11 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.conf.urls import url
-
 from .views import UserCRUDL
 
 urlpatterns = UserCRUDL().as_urlpatterns()
-
-urlpatterns += [
-    url(r'^user/create_in/(?P<partner_id>\d+)/$', UserCRUDL.Create.as_view(), name='profiles.user_create_in')
-]

--- a/casepro/profiles/views.py
+++ b/casepro/profiles/views.py
@@ -281,9 +281,11 @@ class UserCRUDL(SmartCRUDL):
 
         def derive_queryset(self, **kwargs):
             if self.request.org:
-                return self.request.org.get_users().exclude(profile=None)
+                queryset = self.request.org.get_users()
             else:
-                return super(UserCRUDL.List, self).derive_queryset(**kwargs)
+                queryset = super(UserCRUDL.List, self).derive_queryset(**kwargs)
+
+            return queryset.exclude(profile=None)
 
         def lookup_field_link(self, context, field, obj):
             if field == 'partner':

--- a/casepro/profiles/views.py
+++ b/casepro/profiles/views.py
@@ -46,7 +46,7 @@ class UserUpdateMixin(OrgFormMixin):
 
         if 'role' in data:
             role = data['role']
-            partner = data['partner'] if 'partner' in data else self.get_partner(self.request.org)
+            partner = data['partner'] if 'partner' in data else self.get_partner()
             obj.profile.update_role(self.request.org, role, partner)
 
         # set new password if provided
@@ -162,7 +162,7 @@ class UserCRUDL(SmartCRUDL):
                 else:
                     profile_fields += ['role', 'partner']
 
-            return profile_fields + user_fields
+            return tuple(profile_fields + user_fields)
 
         def get_success_url(self):
             return reverse('profiles.user_read', args=[self.object.pk])

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -328,7 +328,7 @@ PERMISSIONS = {
     'contacts.group': ('select', 'list'),
 
     # can't create profiles.user.* permissions because we don't own User
-    'profiles.profile': ('user_create', 'user_read', 'user_list'),
+    'profiles.profile': ('user_create', 'user_create_in', 'user_update', 'user_read', 'user_list'),
 }
 
 # assigns the permissions that each group should have
@@ -383,7 +383,8 @@ GROUP_PERMISSIONS = {
 
         'contacts.contact_read',
 
-        'profiles.profile_user_create',
+        'profiles.profile_user_create_in',
+        'profiles.profile_user_update',
         'profiles.profile_user_read',
     ),
     "Viewers": (  # Partner users: Data Analysts

--- a/casepro/test.py
+++ b/casepro/test.py
@@ -6,12 +6,11 @@ from casepro.backend import NoopBackend
 from casepro.cases.models import Case, Partner
 from casepro.contacts.models import Contact, Group, Field
 from casepro.msgs.models import Label, Message, Outgoing
-from casepro.profiles import ROLE_ANALYST, ROLE_MANAGER
+from casepro.profiles.models import Profile, ROLE_ANALYST, ROLE_MANAGER
 from casepro.rules.models import ContainsTest, Quantifier
 from casepro.utils import json_encode
 from dash.test import DashTest
 from datetime import datetime
-from django.contrib.auth.models import User
 from django.utils.timezone import now
 from django.test import override_settings
 from xlrd import xldate_as_tuple
@@ -75,13 +74,11 @@ class BaseCasesTest(DashTest):
     def create_partner(self, org, name, labels=(), restricted=True):
         return Partner.create(org, name, restricted, labels, None)
 
-    def create_admin(self, org, full_name, email):
-        user = User.create(None, None, None, full_name, email, password=email, change_password=False)
-        org.administrators.add(user)
-        return user
+    def create_admin(self, org, name, email):
+        return Profile.create_org_user(org, name, email, email)
 
-    def create_user(self, org, partner, role, full_name, email):
-        return User.create(org, partner, role, full_name, email, password=email, change_password=False)
+    def create_user(self, org, partner, role, name, email):
+        return Profile.create_partner_user(org, partner, role, name, email, email)
 
     def create_label(self, org, uuid, name, description, keywords, **kwargs):
         tests = json_encode([ContainsTest(keywords, Quantifier.ANY)])

--- a/templates/profiles/user_create.haml
+++ b/templates/profiles/user_create.haml
@@ -1,0 +1,13 @@
+- extends "smartmin/update.html"
+
+- block extra-script
+  {{ block.super }}
+  :javascript
+    $(function() {
+      function onChangeRole() {
+        $('#id_partner').prop("disabled", $('#id_role').val() == 'A');
+      }
+      $('#id_role').on('change', onChangeRole);
+
+      onChangeRole();
+    });

--- a/templates/profiles/user_update.haml
+++ b/templates/profiles/user_update.haml
@@ -1,4 +1,4 @@
-- extends "smartmin/create.html"
+- extends "smartmin/update.html"
 
 - block extra-script
   {{ block.super }}


### PR DESCRIPTION
Reworks user editing UIs so that there 3 views:
1. Creating any kind of user from the org administration (accessible to org admins and superusers)
2. Creating a partner user from the partner dashboard (accessible to partner managers and org admins)
3. Updating any kind of user (accessible to all of above, tho partner managers can't change a user's partner)

Screenshot of 1 when logged in org admin:

<img width="708" alt="screen shot 2016-06-07 at 10 29 05" src="https://cloud.githubusercontent.com/assets/675558/15851503/58ec07ca-2c9d-11e6-813f-cd755e91f387.png">

Options reduced when logged in partner manager

<img width="699" alt="screen shot 2016-06-07 at 11 11 36" src="https://cloud.githubusercontent.com/assets/675558/15852781/c9261166-2ca2-11e6-9f77-1d6f33831d66.png">