### PR TITLE
Change modelling of forwards so that there is one URN per Outgoing

### DIFF
--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -257,8 +257,8 @@ class RapidProBackend(BaseBackend):
             for msg in outgoing:
                 if msg.contact:
                     contact_uuids.append(msg.contact.uuid)
-                if msg.urns:
-                    urns.extend(msg.urns)
+                if msg.urn:
+                    urns.append(msg.urn)
             text = outgoing[0].text
             broadcast = client.create_broadcast(text=text, contacts=contact_uuids, urns=urns)
 
@@ -269,7 +269,8 @@ class RapidProBackend(BaseBackend):
         else:
             for msg in outgoing:
                 contact_uuids = [msg.contact.uuid] if msg.contact else []
-                broadcast = client.create_broadcast(text=msg.text, contacts=contact_uuids, urns=msg.urns)
+                urns = [msg.urn] if msg.urn else []
+                broadcast = client.create_broadcast(text=msg.text, contacts=contact_uuids, urns=urns)
 
                 msg.backend_broadcast_id = broadcast.id
                 msg.save(update_fields=('backend_broadcast_id',))
@@ -335,7 +336,7 @@ class RapidProBackend(BaseBackend):
             return {
                 'id': msg.broadcast,
                 'contact': contact_json,
-                'urns': [],
+                'urn': None,
                 'text': msg.text,
                 'time': msg.created_on,
                 'direction': Outgoing.DIRECTION,

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -673,13 +673,16 @@ class RapidProBackendTest(BaseCasesTest):
             TembaBroadcast.create(id=204, text="FYI", urns=["tel:+250783935665"], contacts=[])
         ]
 
-        out5 = self.create_outgoing(self.unicef, self.user1, None, 'F', "FYI", None, urns=["tel:+250783935665"])
-        self.backend.push_outgoing(self.unicef, [out5])
+        out5 = self.create_outgoing(self.unicef, self.user1, None, 'F', "FYI", None, urn="tel:+1234")
+        out6 = self.create_outgoing(self.unicef, self.user1, None, 'F', "FYI", None, urn="tel:+2345")
+        self.backend.push_outgoing(self.unicef, [out5, out6], as_broadcast=True)
 
-        mock_create_broadcast.assert_called_once_with(text="FYI", contacts=[], urns=["tel:+250783935665"])
+        mock_create_broadcast.assert_called_once_with(text="FYI", contacts=[], urns=["tel:+1234", "tel:+2345"])
 
         out5.refresh_from_db()
+        out6.refresh_from_db()
         self.assertEqual(out5.backend_broadcast_id, 204)
+        self.assertEqual(out6.backend_broadcast_id, 204)
 
     @patch('dash.orgs.models.TembaClient1.add_contacts')
     def test_add_to_group(self, mock_add_contacts):
@@ -826,7 +829,7 @@ class RapidProBackendTest(BaseCasesTest):
             {
                 'id': 201,  # id is the broadcast id
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
-                'urns': [],
+                'urn': None,
                 'text': "Welcome",
                 'time': d3,
                 'direction': 'O',

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -625,7 +625,7 @@ class CaseCRUDLTest(BaseCasesTest):
         remote_message1 = {
             'id': 102,
             'contact': {'id': self.ann.pk, 'name': "Ann"},
-            'urns': [],
+            'urn': None,
             'text': "Non casepro message...",
             'time': d2,
             'direction': 'O',
@@ -745,7 +745,7 @@ class CaseCRUDLTest(BaseCasesTest):
             {
                 'id': 202,
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
-                'urns': [],
+                'urn': None,
                 'text': "It's bad",
                 'time': d3,
                 'direction': 'O',

--- a/casepro/msgs/migrations/0047_outgoing_urn.py
+++ b/casepro/msgs/migrations/0047_outgoing_urn.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def populate_outgoing_urn(apps, schema_editor):
+    Outgoing = apps.get_model('msgs', 'Outgoing')
+
+    fwds = Outgoing.objects.filter(activity='F')
+
+    for fwd in fwds:
+        fwd.urn = fwd.urns[0] if fwd.urns else ""
+        fwd.save(update_fields=('urn',))
+
+    if fwds:
+        print("Updated %d forwards" % len(fwds))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0046_exports_partner'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='outgoing',
+            name='urn',
+            field=models.CharField(max_length=255, null=True),
+        ),
+        migrations.RunPython(populate_outgoing_urn),
+        migrations.RemoveField(
+            model_name='outgoing',
+            name='urns',
+        ),
+    ]

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -283,8 +283,8 @@ class MessageCRUDL(SmartCRUDL):
             message = Message.objects.get(org=request.org, backend_id=int(kwargs['id']))
             urns = request.json['urns']
 
-            out = Outgoing.create_forward(request.org, request.user, text, urns, message)
-            return JsonResponse({'id': out.pk})
+            outgoing = Outgoing.create_forwards(request.org, request.user, text, urns, message)
+            return JsonResponse({'messages': len(outgoing)})
 
     class History(OrgPermsMixin, SmartTemplateView):
         """


### PR DESCRIPTION
Outgoing instances in CasePro used to model broadcasts in RapidPro. This makes forwards more like replies in that they model a single message, and is a preparation step for actually surfacing forwards somewhere in the UI - like the Replies tab on the partner pages.