### PR TITLE
Labelling improvements

### DIFF
--- a/casepro/msgs/forms.py
+++ b/casepro/msgs/forms.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from casepro.contacts.models import Group
 from casepro.rules.forms import FieldTestField
+from casepro.rules.models import ContainsTest
 from casepro.utils import parse_csv, normalize
 
 from .models import Label
@@ -63,16 +64,10 @@ class LabelForm(forms.ModelForm):
         return name
 
     def clean_keywords(self):
-        from casepro.rules.models import ContainsTest
-
         keywords = parse_csv(self.cleaned_data['keywords'])
         clean_keywords = []
         for keyword in keywords:
             clean_keyword = normalize(keyword)
-
-            if len(keyword) < ContainsTest.KEYWORD_MIN_LENGTH:
-                raise forms.ValidationError(_("Keywords must be at least %d characters long")
-                                            % ContainsTest.KEYWORD_MIN_LENGTH)
 
             if not ContainsTest.is_valid_keyword(keyword):
                 raise forms.ValidationError(_("Invalid keyword: %s") % keyword)

--- a/casepro/msgs/forms.py
+++ b/casepro/msgs/forms.py
@@ -12,19 +12,29 @@ from .models import Label
 
 class LabelForm(forms.ModelForm):
     name = forms.CharField(label=_("Name"), max_length=128)
+
     description = forms.CharField(label=_("Description"), max_length=255, widget=forms.Textarea)
+
+    is_synced = forms.BooleanField(
+        label=_("Is synced"), required=False,
+        help_text=_("Whether label should be kept synced with backend")
+    )
+
     keywords = forms.CharField(
         label=_("Keywords"), widget=forms.Textarea, required=False,
         help_text=_("Match messages containing any of these words (comma separated)")
     )
+
     groups = forms.ModelMultipleChoiceField(
         queryset=Group.objects.none(), label=_("Groups"), required=False,
         help_text=_("Match messages from these groups (select none to include all groups)")
     )
+
     field_test = forms.CharField()  # switched below in __init__
-    is_synced = forms.BooleanField(
-        label=_("Is synced"), required=False,
-        help_text=_("Whether label should be kept synced with backend")
+
+    ignore_single_words = forms.BooleanField(
+        label=_("Ignore single words"), required=False,
+        help_text=_("Whether label should be applied to single word messages")
     )
 
     def __init__(self, *args, **kwargs):
@@ -73,4 +83,4 @@ class LabelForm(forms.ModelForm):
 
     class Meta:
         model = Label
-        fields = ('name', 'description', 'keywords', 'groups', 'field_test', 'is_synced')
+        fields = ('name', 'description', 'is_synced', 'keywords', 'groups', 'field_test', 'ignore_single_words')

--- a/casepro/msgs/migrations/0048_label_rule.py
+++ b/casepro/msgs/migrations/0048_label_rule.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def create_label_rules(apps, schema_editor):
+    Rule = apps.get_model('rules', 'Rule')
+    Label = apps.get_model('msgs', 'Label')
+
+    num_created = 0
+
+    for label in Label.objects.all().select_related('org'):
+        if label.tests:
+            label.rule = Rule.objects.create(org=label.org,
+                                             tests=label.tests,
+                                             actions='[{"type": "label", "label": %d}]' % label.pk)
+            label.save(update_fields=('rule',))
+            num_created += 1
+
+    if num_created:
+        print("Converted %d label tests to rules" % num_created)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rules', '0001_initial'),
+        ('msgs', '0047_outgoing_urn'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='label',
+            name='rule',
+            field=models.OneToOneField(null=True, to='rules.Rule'),
+        ),
+        migrations.RunPython(create_label_rules)
+    ]

--- a/casepro/msgs/migrations/0049_remove_label_tests.py
+++ b/casepro/msgs/migrations/0049_remove_label_tests.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('msgs', '0048_label_rule'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='label',
+            name='tests',
+        ),
+    ]

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import json
-
 from dash.orgs.models import Org
 from django.contrib.auth.models import User
 from django.db import models

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -156,6 +156,7 @@ class LabelCRUDLTest(BaseCasesTest):
         self.assertEqual(response.status_code, 302)
 
         self.pregnancy.refresh_from_db()
+        self.pregnancy.rule.refresh_from_db()
         self.assertEqual(self.pregnancy.uuid, 'L-002')
         self.assertEqual(self.pregnancy.org, self.unicef)
         self.assertEqual(self.pregnancy.name, "Pregnancy")
@@ -170,6 +171,25 @@ class LabelCRUDLTest(BaseCasesTest):
         # view form again for recently edited label
         response = self.url_get('unicef', url)
         self.assertEqual(response.status_code, 200)
+
+        # submit again with no tests
+        response = self.url_post('unicef', url, {
+            'name': "Pregnancy",
+            'description': "Msgs about maternity",
+            'keywords': "",
+            'field_test_0': "",
+            'field_test_1': "",
+            'is_synced': "1"
+        })
+
+        self.assertEqual(response.status_code, 302)
+
+        self.pregnancy.refresh_from_db()
+        self.assertEqual(self.pregnancy.rule, None)
+        self.assertEqual(self.pregnancy.get_tests(), [])
+
+        self.assertEqual(self.unicef.labels.count(), 3)
+        self.assertEqual(self.unicef.rules.count(), 2)
 
     def test_list(self):
         url = reverse('msgs.label_list')

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -90,7 +90,7 @@ class LabelCRUDLTest(BaseCasesTest):
         # submit with a keyword that is too short
         response = self.url_post('unicef', url, {'name': 'Ebola', 'keywords': 'a, ebola'})
         self.assertEqual(response.status_code, 200)
-        self.assertFormError(response, 'form', 'keywords', "Keywords must be at least 3 characters long")
+        self.assertFormError(response, 'form', 'keywords', "Invalid keyword: a")
 
         # submit with a keyword that is invalid
         response = self.url_post('unicef', url, {'name': 'Ebola', 'keywords': r'ebol@?, ebola'})

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -15,7 +15,7 @@ from temba_client.utils import format_iso8601
 from xlrd import open_workbook
 
 from casepro.contacts.models import Contact
-from casepro.rules.models import ContainsTest, GroupsTest, FieldTest, Quantifier
+from casepro.rules.models import ContainsTest, GroupsTest, FieldTest, WordCountTest, Quantifier
 from casepro.test import BaseCasesTest
 
 from .models import Label, Message, MessageAction, MessageExport, MessageFolder, Outgoing, OutgoingFolder, ReplyExport
@@ -105,6 +105,7 @@ class LabelCRUDLTest(BaseCasesTest):
             'groups': '%d' % self.reporters.pk,
             'field_test_0': "state",
             'field_test_1': "Kigali,Lusaka",
+            'ignore_single_words': "1"
         })
 
         self.assertEqual(response.status_code, 302)
@@ -117,7 +118,8 @@ class LabelCRUDLTest(BaseCasesTest):
         self.assertEqual(label.get_tests(), [
             ContainsTest(['ebola', 'fever'], Quantifier.ANY),
             GroupsTest([self.reporters], Quantifier.ANY),
-            FieldTest('state', ["Kigali", "Lusaka"])
+            FieldTest('state', ["Kigali", "Lusaka"]),
+            WordCountTest(2)
         ])
         self.assertEqual(label.is_synced, False)
 
@@ -150,7 +152,8 @@ class LabelCRUDLTest(BaseCasesTest):
             'groups': '%d' % self.males.pk,
             'field_test_0': "age",
             'field_test_1': "18,19,20",
-            'is_synced': "1"
+            'is_synced': "1",
+            'ignore_single_words': "1"
         })
 
         self.assertEqual(response.status_code, 302)
@@ -164,7 +167,8 @@ class LabelCRUDLTest(BaseCasesTest):
         self.assertEqual(self.pregnancy.get_tests(), [
             ContainsTest(['pregnancy', 'maternity'], Quantifier.ANY),
             GroupsTest([self.males], Quantifier.ANY),
-            FieldTest('age', ["18", "19", "20"])
+            FieldTest('age', ["18", "19", "20"]),
+            WordCountTest(2)
         ])
         self.assertEqual(self.pregnancy.is_synced, True)
 

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -100,11 +100,11 @@ class LabelCRUDL(SmartCRUDL):
 
             return initial
 
-        def pre_save(self, obj):
-            obj = super(LabelCRUDL.Update, self).pre_save(obj)
+        def post_save(self, obj):
+            obj = super(LabelCRUDL.Update, self).post_save(obj)
 
             tests = self.construct_tests(self.form.cleaned_data)
-            obj.tests = json_encode(tests) if tests else ""
+            obj.update_tests(tests)
 
             return obj
 

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -13,8 +13,8 @@ from smartmin.views import SmartCRUDL, SmartTemplateView
 from smartmin.views import SmartListView, SmartCreateView, SmartUpdateView, SmartDeleteView
 from temba_client.utils import parse_iso8601
 
-from casepro.rules.models import ContainsTest, GroupsTest, Quantifier
-from casepro.utils import parse_csv, str_to_bool, json_encode, JSONEncoder
+from casepro.rules.mixins import RuleFormMixin
+from casepro.utils import parse_csv, str_to_bool, JSONEncoder
 from casepro.utils.export import BaseDownloadView
 
 from .forms import LabelForm
@@ -25,29 +25,11 @@ from .tasks import message_export, reply_export
 RESPONSE_DELAY_WARN_SECONDS = 24 * 60 * 60  # show response delays > 1 day as warning
 
 
-class LabelFormMixin(object):
-    @staticmethod
-    def construct_tests(data):
-        keywords = parse_csv(data['keywords'])
-        groups = data['groups']
-        field_test = data['field_test']
-
-        tests = []
-        if keywords:
-            tests.append(ContainsTest(keywords, Quantifier.ANY))
-        if groups:
-            tests.append(GroupsTest(groups, Quantifier.ANY))
-        if field_test:
-            tests.append(field_test)
-
-        return tests
-
-
 class LabelCRUDL(SmartCRUDL):
     actions = ('create', 'update', 'delete', 'list')
     model = Label
 
-    class Create(LabelFormMixin, OrgPermsMixin, SmartCreateView):
+    class Create(RuleFormMixin, OrgPermsMixin, SmartCreateView):
         form_class = LabelForm
 
         def get_form_kwargs(self):
@@ -67,12 +49,12 @@ class LabelCRUDL(SmartCRUDL):
             org = self.request.org
             name = data['name']
             description = data['description']
-            tests = self.construct_tests(data)
+            tests = self.construct_tests()
             is_synced = data['is_synced']
 
             self.object = Label.create(org, name, description, tests, is_synced)
 
-    class Update(LabelFormMixin, OrgObjPermsMixin, SmartUpdateView):
+    class Update(RuleFormMixin, OrgObjPermsMixin, SmartUpdateView):
         form_class = LabelForm
 
         def get_form_kwargs(self):
@@ -81,29 +63,10 @@ class LabelCRUDL(SmartCRUDL):
             kwargs['is_create'] = False
             return kwargs
 
-        def derive_initial(self):
-            initial = super(LabelCRUDL.Update, self).derive_initial()
-
-            tests_by_type = {t.TYPE: t for t in self.object.get_tests()}
-            contains_test = tests_by_type.get('contains')
-            groups_test = tests_by_type.get('groups')
-            field_test = tests_by_type.get('field')
-
-            if contains_test:
-                initial['keywords'] = ", ".join(contains_test.keywords)
-
-            if groups_test:
-                initial['groups'] = groups_test.groups
-
-            if field_test:
-                initial['field_test'] = field_test
-
-            return initial
-
         def post_save(self, obj):
             obj = super(LabelCRUDL.Update, self).post_save(obj)
 
-            tests = self.construct_tests(self.form.cleaned_data)
+            tests = self.construct_tests()
             obj.update_tests(tests)
 
             return obj

--- a/casepro/rules/migrations/0001_initial.py
+++ b/casepro/rules/migrations/0001_initial.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('orgs', '0016_taskstate_is_disabled'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Rule',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('tests', models.TextField()),
+                ('actions', models.TextField()),
+                ('org', models.ForeignKey(related_name='rules', verbose_name='Organization', to='orgs.Org')),
+            ],
+        ),
+    ]

--- a/casepro/rules/mixins.py
+++ b/casepro/rules/mixins.py
@@ -1,0 +1,51 @@
+from __future__ import unicode_literals
+
+from casepro.utils import parse_csv
+
+from .models import ContainsTest, GroupsTest, WordCountTest, Quantifier
+
+
+class RuleFormMixin(object):
+    def derive_initial(self):
+        initial = super(RuleFormMixin, self).derive_initial()
+
+        if self.object:
+            tests_by_type = {t.TYPE: t for t in self.object.get_tests()}
+            contains_test = tests_by_type.get('contains')
+            groups_test = tests_by_type.get('groups')
+            field_test = tests_by_type.get('field')
+            words_test = tests_by_type.get('words')
+
+            if contains_test:
+                initial['keywords'] = ", ".join(contains_test.keywords)
+            if groups_test:
+                initial['groups'] = groups_test.groups
+            if field_test:
+                initial['field_test'] = field_test
+            if words_test:
+                initial['ignore_single_words'] = True
+
+        return initial
+
+    def construct_tests(self):
+        """
+        Constructs tests from form field values
+        """
+        data = self.form.cleaned_data
+
+        keywords = parse_csv(data['keywords'])
+        groups = data['groups']
+        field_test = data['field_test']
+        ignore_single_words = data['ignore_single_words']
+
+        tests = []
+        if keywords:
+            tests.append(ContainsTest(keywords, Quantifier.ANY))
+        if groups:
+            tests.append(GroupsTest(groups, Quantifier.ANY))
+        if field_test:
+            tests.append(field_test)
+        if ignore_single_words:
+            tests.append(WordCountTest(2))
+
+        return tests

--- a/casepro/rules/models.py
+++ b/casepro/rules/models.py
@@ -311,7 +311,7 @@ class LabelAction(Action):
         return {'type': self.TYPE, 'label': self.label.pk}
 
     def get_description(self):
-        return "label with '%s'" % self.label.name
+        return "apply label '%s'" % self.label.name
 
     def apply_to(self, org, messages):
         for msg in messages:

--- a/casepro/rules/models.py
+++ b/casepro/rules/models.py
@@ -1,17 +1,21 @@
 from __future__ import unicode_literals
 
+import json
 import regex
 import six
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+from dash.orgs.models import Org
+from dash.utils import get_obj_cacheable
+from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from enum import Enum
 
 from casepro.backend import get_backend
 from casepro.contacts.models import Group
 from casepro.msgs.models import Label, Message
-from casepro.utils import normalize
+from casepro.utils import normalize, json_encode
 
 
 class Quantifier(Enum):
@@ -89,6 +93,14 @@ class Test(object):
         return test_cls.from_json(json_obj, context)
 
     @abstractmethod
+    def to_json(self):  # pragma: no cover
+        pass
+
+    @abstractmethod
+    def get_description(self):  # pragma: no cover
+        pass
+
+    @abstractmethod
     def matches(self, message):
         """
         Subclasses must implement this to return a boolean.
@@ -99,9 +111,6 @@ class Test(object):
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
-    def __str__(self):
-        return str(unicode(self))
 
 
 class ContainsTest(Test):
@@ -123,6 +132,10 @@ class ContainsTest(Test):
     def to_json(self):
         return {'type': self.TYPE, 'keywords': self.keywords, 'quantifier': self.quantifier.to_json()}
 
+    def get_description(self):
+        quoted_keywords = ['"%s"' % w for w in self.keywords]
+        return "message contains %s %s" % (six.text_type(self.quantifier), ", ".join(quoted_keywords))
+
     def matches(self, message):
         text = normalize(message.text)
 
@@ -141,10 +154,6 @@ class ContainsTest(Test):
         return other and self.TYPE == other.TYPE \
                and self.keywords == other.keywords and self.quantifier == other.quantifier
 
-    def __unicode__(self):
-        quoted_keywords = ['"%s"' % w for w in self.keywords]
-        return "message contains %s %s" % (six.text_type(self.quantifier), ", ".join(quoted_keywords))
-
 
 class WordCountTest(Test):
     """
@@ -162,15 +171,15 @@ class WordCountTest(Test):
     def to_json(self):
         return {'type': self.TYPE, 'minimum': self.minimum}
 
+    def get_description(self):
+        return "message has at least %d words" % self.minimum
+
     def matches(self, message):
         num_words = len(regex.findall(r'\w+', message.text, flags=regex.UNICODE | regex.V0))
         return num_words >= self.minimum
 
     def __eq__(self, other):
         return other and self.TYPE == other.TYPE and self.minimum == other.minimum
-
-    def __unicode__(self):
-        return "message has at least %d words" % self.minimum
 
 
 class GroupsTest(Test):
@@ -191,6 +200,10 @@ class GroupsTest(Test):
     def to_json(self):
         return {'type': self.TYPE, 'groups': [g.pk for g in self.groups], 'quantifier': self.quantifier.to_json()}
 
+    def get_description(self):
+        group_names = [g.name for g in self.groups]
+        return "contact belongs to %s %s" % (six.text_type(self.quantifier), ", ".join(group_names))
+
     def matches(self, message):
         contact_groups = set(message.contact.groups.all())
 
@@ -203,10 +216,6 @@ class GroupsTest(Test):
 
     def __eq__(self, other):
         return other and self.TYPE == other.TYPE and self.groups == other.groups and self.quantifier == other.quantifier
-
-    def __unicode__(self):
-        group_names = [g.name for g in self.groups]
-        return "contact belongs to %s %s" % (six.text_type(self.quantifier), ", ".join(group_names))
 
 
 class FieldTest(Test):
@@ -226,6 +235,10 @@ class FieldTest(Test):
     def to_json(self):
         return {'type': self.TYPE, 'key': self.key, 'values': self.values}
 
+    def get_description(self):
+        quoted_values = ['"%s"' % v for v in self.values]
+        return "contact.%s is %s %s" % (self.key, Quantifier.ANY, ", ".join(quoted_values))
+
     def matches(self, message):
         contact_value = normalize(message.contact.fields.get(self.key, ""))
 
@@ -236,10 +249,6 @@ class FieldTest(Test):
 
     def __eq__(self, other):
         return other and self.TYPE == other.TYPE and self.key == other.key and self.values == other.values
-
-    def __unicode__(self):
-        quoted_values = ['"%s"' % v for v in self.values]
-        return "contact.%s is %s %s" % (self.key, Quantifier.ANY, ", ".join(quoted_values))
 
 
 class Action(object):
@@ -267,6 +276,14 @@ class Action(object):
 
         return action_cls.from_json(json_obj, context)
 
+    @abstractmethod
+    def to_json(self):  # pragma: no cover
+        pass
+
+    @abstractmethod
+    def get_description(self):  # pragma: no cover
+        pass
+
     def __eq__(self, other):
         return self.TYPE == other.TYPE
 
@@ -292,6 +309,9 @@ class LabelAction(Action):
 
     def to_json(self):
         return {'type': self.TYPE, 'label': self.label.pk}
+
+    def get_description(self):
+        return "label with '%s'" % self.label.name
 
     def apply_to(self, org, messages):
         for msg in messages:
@@ -320,6 +340,9 @@ class FlagAction(Action):
     def to_json(self):
         return {'type': self.TYPE}
 
+    def get_description(self):
+        return "flag"
+
     def apply_to(self, org, messages):
         Message.objects.filter(pk__in=[m.pk for m in messages]).update(is_flagged=True)
 
@@ -339,52 +362,59 @@ class ArchiveAction(Action):
     def to_json(self):
         return {'type': self.TYPE}
 
+    def get_description(self):
+        return "archive"
+
     def apply_to(self, org, messages):
         Message.objects.filter(pk__in=[m.pk for m in messages]).update(is_archived=True)
 
         get_backend().archive_messages(org, messages)
 
 
-class Rule(object):
+class Rule(models.Model):
     """
-    At some point this we'll likely separate rules from labels and this will become an actual model. For now we generate
-    rules from labels on the fly.
+    At some point this will become a first class object, but for now it is always attached to a label.
     """
-    def __init__(self, tests, actions):
-        self.tests = tests
-        self.actions = actions
+    org = models.ForeignKey(Org, verbose_name=_("Organization"), related_name='rules')
+
+    tests = models.TextField()
+
+    actions = models.TextField()
+
+    @classmethod
+    def create(cls, org, tests, actions):
+        return cls.objects.create(org=org, tests=json_encode(tests), actions=json_encode(actions))
 
     @classmethod
     def get_all(cls, org):
-        """
-        Loads all org labels and converts them to rules
-        """
-        rules = []
-        for label in Label.get_all(org).order_by('pk'):
-            rule = cls.from_label(label)
-            if rule:
-                rules.append(rule)
-        return rules
+        return org.rules.all()
 
-    @classmethod
-    def from_label(cls, label):
-        """
-        Converts a label to a rule. Returns none if label doesn't have any tests so can't be a rule.
-        """
-        tests = label.get_tests()
-        return Rule(tests, [LabelAction(label)]) if tests else None
+    def get_tests(self):
+        return get_obj_cacheable(self, '_tests', lambda: self._get_tests())
+
+    def _get_tests(self):
+        return [Test.from_json(t, DeserializationContext(self.org)) for t in json.loads(self.tests)]
+
+    def get_tests_description(self):
+        return _(" and ").join([t.get_description() for t in self.get_tests()])
+
+    def get_actions(self):
+        return get_obj_cacheable(self, '_actions', lambda: self._get_actions())
+
+    def _get_actions(self):
+        return [Action.from_json(a, DeserializationContext(self.org)) for a in json.loads(self.actions)]
+
+    def get_actions_description(self):
+        return _(" and ").join([a.get_description() for a in self.get_actions()])
 
     def matches(self, message):
         """
         Returns whether this rule matches the given message, i.e. all of its tests match the message
         """
-        for test in self.tests:
+        for test in self.get_tests():
             if not test.matches(message):
                 return False
         return True
-
-    def get_tests_description(self):
-        return _(" and ").join([six.text_type(t) for t in self.tests])
 
     class BatchProcessor(object):
         """
@@ -409,7 +439,7 @@ class Rule(object):
                 for rule in self.rules:
                     if rule.matches(message):
                         num_rules_matched += 1
-                        for action in rule.actions:
+                        for action in rule.get_actions():
                             self.messages_by_action[action].add(message)
                             num_actions_deferred += 1
 

--- a/casepro/rules/models.py
+++ b/casepro/rules/models.py
@@ -18,6 +18,9 @@ from casepro.msgs.models import Label, Message
 from casepro.utils import normalize, json_encode
 
 
+KEYWORD_REGEX = regex.compile(r'^\w[\w\- ]*\w$', flags=regex.UNICODE | regex.V0)
+
+
 class Quantifier(Enum):
     """
     Tests are typically composed of multiple conditions, e.g. contains ANY of X, Y or Z.
@@ -119,8 +122,6 @@ class ContainsTest(Test):
     """
     TYPE = 'contains'
 
-    KEYWORD_MIN_LENGTH = 3
-
     def __init__(self, keywords, quantifier):
         self.keywords = [normalize(word) for word in keywords]
         self.quantifier = quantifier
@@ -148,7 +149,7 @@ class ContainsTest(Test):
 
     @classmethod
     def is_valid_keyword(cls, keyword):
-        return len(keyword) >= cls.KEYWORD_MIN_LENGTH and regex.match(r'^\w[\w\- ]*\w$', keyword)
+        return KEYWORD_REGEX.match(keyword)
 
     def __eq__(self, other):
         return other and self.TYPE == other.TYPE \

--- a/casepro/rules/models.py
+++ b/casepro/rules/models.py
@@ -76,6 +76,7 @@ class Test(object):
         if not cls.CLASS_BY_TYPE:
             cls.CLASS_BY_TYPE = {
                 ContainsTest.TYPE: ContainsTest,
+                WordCountTest.TYPE: WordCountTest,
                 GroupsTest.TYPE: GroupsTest,
                 FieldTest.TYPE: FieldTest,
             }
@@ -143,6 +144,33 @@ class ContainsTest(Test):
     def __unicode__(self):
         quoted_keywords = ['"%s"' % w for w in self.keywords]
         return "message contains %s %s" % (six.text_type(self.quantifier), ", ".join(quoted_keywords))
+
+
+class WordCountTest(Test):
+    """
+    Test that returns whether the message text contains at least the given number of words
+    """
+    TYPE = 'words'
+
+    def __init__(self, minimum):
+        self.minimum = minimum
+
+    @classmethod
+    def from_json(cls, json_obj, context):
+        return cls(json_obj['minimum'])
+
+    def to_json(self):
+        return {'type': self.TYPE, 'minimum': self.minimum}
+
+    def matches(self, message):
+        num_words = len(regex.findall(r'\w+', message.text, flags=regex.UNICODE | regex.V0))
+        return num_words >= self.minimum
+
+    def __eq__(self, other):
+        return other and self.TYPE == other.TYPE and self.minimum == other.minimum
+
+    def __unicode__(self):
+        return "message has at least %d words" % self.minimum
 
 
 class GroupsTest(Test):

--- a/casepro/rules/tests.py
+++ b/casepro/rules/tests.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import six
-
 from mock import patch, call
 
 from casepro.msgs.models import Message

--- a/casepro/rules/tests.py
+++ b/casepro/rules/tests.py
@@ -136,6 +136,7 @@ class ActionsTest(BaseCasesTest):
         self.assertEqual(action.TYPE, 'label')
         self.assertEqual(action.label, self.aids)
         self.assertEqual(action.to_json(), {'type': 'label', 'label': self.aids.pk})
+        self.assertEqual(action.get_description(), "apply label 'AIDS'")
 
         self.assertEqual(action, LabelAction(self.aids))
         self.assertNotEqual(action, LabelAction(self.pregnancy))
@@ -149,6 +150,7 @@ class ActionsTest(BaseCasesTest):
         action = Action.from_json({'type': 'flag'}, self.context)
         self.assertEqual(action.TYPE, 'flag')
         self.assertEqual(action.to_json(), {'type': 'flag'})
+        self.assertEqual(action.get_description(), "flag")
 
         self.assertEqual(action, FlagAction())
         self.assertNotEqual(action, ArchiveAction())
@@ -163,6 +165,7 @@ class ActionsTest(BaseCasesTest):
         action = Action.from_json({'type': 'archive'}, self.context)
         self.assertEqual(action.TYPE, 'archive')
         self.assertEqual(action.to_json(), {'type': 'archive'})
+        self.assertEqual(action.get_description(), "archive")
 
         self.assertEqual(action, ArchiveAction())
         self.assertNotEqual(action, FlagAction())
@@ -198,6 +201,11 @@ class RuleTest(BaseCasesTest):
         self.assertEqual(rule.get_tests_description(), 'message contains any of "aids", "hiv" '
                                                        'and contact belongs to all of Females, Reporters '
                                                        'and contact.city is any of "kigali", "lusaka"')
+
+    def test_get_actions_description(self):
+        rule = self.create_rule(self.unicef, [], [LabelAction(self.tea), ArchiveAction(), FlagAction()])
+
+        self.assertEqual(rule.get_actions_description(), "apply label 'Tea' and archive and flag")
 
     @patch('casepro.test.TestBackend.label_messages')
     @patch('casepro.test.TestBackend.flag_messages')

--- a/casepro/rules/tests.py
+++ b/casepro/rules/tests.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import unicode_literals
 
 from mock import patch, call
@@ -110,12 +111,13 @@ class TestsTest(BaseCasesTest):
         self.assertTest(test, self.cat, "Yes", False)
 
     def test_is_valid_keyword(self):
+        self.assertTrue(ContainsTest.is_valid_keyword('tú'))
         self.assertTrue(ContainsTest.is_valid_keyword('kit'))
         self.assertTrue(ContainsTest.is_valid_keyword('kit-kat'))
         self.assertTrue(ContainsTest.is_valid_keyword('kit kat'))
         self.assertTrue(ContainsTest.is_valid_keyword('kit-kat wrapper'))
 
-        self.assertFalse(ContainsTest.is_valid_keyword('it'))  # too short
+        self.assertFalse(ContainsTest.is_valid_keyword('i'))  # too short
         self.assertFalse(ContainsTest.is_valid_keyword(' kitkat'))  # can't start with a space
         self.assertFalse(ContainsTest.is_valid_keyword('-kit'))  # can't start with a dash
         self.assertFalse(ContainsTest.is_valid_keyword('kat '))  # can't end with a space

--- a/casepro/rules/tests.py
+++ b/casepro/rules/tests.py
@@ -8,7 +8,7 @@ from casepro.msgs.models import Message
 from casepro.test import BaseCasesTest
 
 from .models import Action, LabelAction, ArchiveAction, FlagAction
-from .models import Test, ContainsTest, GroupsTest, FieldTest, Rule, DeserializationContext, Quantifier
+from .models import Test, ContainsTest, WordCountTest, GroupsTest, FieldTest, Rule, DeserializationContext, Quantifier
 
 
 class TestsTest(BaseCasesTest):
@@ -54,6 +54,21 @@ class TestsTest(BaseCasesTest):
         self.assertTest(test, self.ann, "Fred Blueth", True)
         self.assertTest(test, self.ann, "red", False)
         self.assertTest(test, self.ann, "yo RED Blue", False)
+
+    def test_word_count(self):
+        test = Test.from_json({'type': 'words', 'minimum': 2}, self.context)
+        self.assertEqual(test.TYPE, 'words')
+        self.assertEqual(test.minimum, 2)
+        self.assertEqual(test.to_json(), {'type': 'words', 'minimum': 2})
+        self.assertEqual(six.text_type(test), 'message has at least 2 words')
+
+        self.assertEqual(test, WordCountTest(2))
+        self.assertNotEqual(test, WordCountTest(3))
+
+        self.assertTest(test, self.ann, "!", False)
+        self.assertTest(test, self.ann, "no!", False)
+        self.assertTest(test, self.ann, "ok  maybe ", True)
+        self.assertTest(test, self.ann, "uh-ok-sure", True)
 
     def test_groups(self):
         test = Test.from_json(

--- a/casepro/rules/urls.py
+++ b/casepro/rules/urls.py
@@ -1,0 +1,5 @@
+from __future__ import unicode_literals
+
+from .views import RuleCRUDL
+
+urlpatterns = RuleCRUDL().as_urlpatterns()

--- a/casepro/rules/views.py
+++ b/casepro/rules/views.py
@@ -1,0 +1,26 @@
+from __future__ import unicode_literals
+
+from dash.orgs.views import OrgPermsMixin
+from smartmin.views import SmartCRUDL, SmartListView
+
+from .models import Rule
+
+
+class RuleCRUDL(SmartCRUDL):
+    """
+    Simple CRUDL for debugging by superusers, i.e. not exposed to regular users for now
+    """
+    model = Rule
+    actions = ('list',)
+
+    class List(OrgPermsMixin, SmartListView):
+        fields = ('tests', 'actions')
+
+        def get_queryset(self, **kwargs):
+            return self.model.objects.filter(org=self.request.org).order_by('pk')
+
+        def get_tests(self, obj):
+            return obj.get_tests_description()
+
+        def get_actions(self, obj):
+            return obj.get_actions_description()

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -353,6 +353,8 @@ GROUP_PERMISSIONS = {
         'contacts.field.*',
 
         'profiles.profile.*',
+
+        'rules.rule.*',
     ),
     "Editors": (  # Partner users: Managers
         'orgs.org_inbox',

--- a/casepro/urls.py
+++ b/casepro/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'', include('casepro.cases.urls')),
     url(r'', include('casepro.contacts.urls')),
     url(r'', include('casepro.msgs.urls')),
+    url(r'', include('casepro.rules.urls')),
     url(r'', include('casepro.profiles.urls')),
     url(r'^manage/', include('casepro.orgs_ext.urls')),
     url(r'^users/', include('dash.users.urls')),

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -97,7 +97,7 @@ describe('controllers:', () ->
         CaseService = _CaseService_
       )
 
-      $window.contextData = {user: test.user1, partners: [], labels: [], groups: []}
+      $window.contextData = {user: test.user1, partners: [], labels: [test.tea, test.coffee], groups: []}
 
       $homeScope = $rootScope.$new()
       $controller('HomeController', {$scope: $homeScope})
@@ -190,6 +190,13 @@ describe('controllers:', () ->
         test.msg1 = {id: 101, text: "Hello 1", labels: [test.tea], flagged: true, archived: false}
         test.msg2 = {id: 102, text: "Hello 2", labels: [test.coffee], flagged: false, archived: false}
         test.msg3 = {id: 103, text: "Hello 3", labels: [], flagged: false, archived: false}
+      )
+
+      it('should initialize correctly', () ->
+        expect($scope.items).toEqual([])
+        expect($scope.activeLabel).toEqual(null)
+        expect($scope.activeContact).toEqual(null)
+        expect($scope.inactiveLabels).toEqual([test.tea, test.coffee])
       )
 
       it('loadOldItems', () ->

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -29,6 +29,7 @@ controllers.controller('HomeController', ['$scope', '$window', '$location', 'Lab
 
   $scope.activeLabel = null
   $scope.activeContact = null
+  $scope.inactiveLabels = $scope.labels
 
   $scope.init = (folder, serverTime) ->
     $scope.folder = folder


### PR DESCRIPTION
- Adds option to ignore single word messages
- Fixes bug on home page where labelling dropdown isn't populated until active label is changed
- Adds support for non-ascii keywords
- Changes keyword min length to 2
- Adds basic rule list page (not linked from anywhere for now, really just for debugging)