### PR TITLE
Don't let users remove labels they don't have access to

### DIFF
--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -519,6 +519,9 @@ class CaseCRUDLTest(BaseCasesTest):
         # log in as manager user in currently assigned partner
         self.login(self.user1)
 
+        # add additional label to case which this user can't access
+        self.case.labels.add(self.tea)
+
         response = self.url_post_json('unicef', url, {'labels': [self.pregnancy.pk]})
         self.assertEqual(response.status_code, 204)
 
@@ -529,8 +532,9 @@ class CaseCRUDLTest(BaseCasesTest):
         self.assertEqual(actions[1].action, CaseAction.UNLABEL)
         self.assertEqual(actions[1].label, self.aids)
 
+        # check that tea label wasn't removed as this user doesn't have access to that label
         self.case.refresh_from_db()
-        self.assertEqual(set(self.case.labels.all()), {self.pregnancy})
+        self.assertEqual(set(self.case.labels.all()), {self.pregnancy, self.tea})
 
         # only user from assigned partner can label
         self.login(self.user3)

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -707,7 +707,7 @@ class MessageCRUDLTest(BaseCasesTest):
     @patch('casepro.test.TestBackend.label_messages')
     @patch('casepro.test.TestBackend.unlabel_messages')
     def test_label(self, mock_unlabel_messages, mock_label_messages):
-        msg1 = self.create_message(self.unicef, 101, self.ann, "Normal", [self.aids])
+        msg1 = self.create_message(self.unicef, 101, self.ann, "Normal", [self.aids, self.tea])
 
         url = reverse('msgs.message_label', kwargs={'id': 101})
 
@@ -720,8 +720,9 @@ class MessageCRUDLTest(BaseCasesTest):
         mock_label_messages.assert_called_once_with(self.unicef, [msg1], self.pregnancy)
         mock_unlabel_messages.assert_called_once_with(self.unicef, [msg1], self.aids)
 
+        # check that tea label wasn't removed as this user doesn't have access to that label
         msg1.refresh_from_db()
-        self.assertEqual(set(msg1.labels.all()), {self.pregnancy})
+        self.assertEqual(set(msg1.labels.all()), {self.pregnancy, self.tea})
 
     def test_bulk_reply(self):
         self.create_message(self.unicef, 101, self.ann, "Hello")


### PR DESCRIPTION
Users can apply individual labels to messages and cases, or open a labelling modal that let's them select multiple labels. This doesn't show labels that the user doesn't have access to, and these labels were then being removed when the modal form was submitted.