### PR TITLE
Case activity notification changes

### DIFF
--- a/casepro/cases/migrations/0039_populate_case_watchers.py
+++ b/casepro/cases/migrations/0039_populate_case_watchers.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def populate_case_watchers(apps, schema_editor):
+    Case = apps.get_model('cases', 'Case')
+
+    cases = Case.objects.all()
+
+    for case in cases:
+        # get all users who have sent replies in this case
+        repliers = {o.created_by for o in case.outgoing_messages.all()}
+
+        # get all users who have acted on this case in a way that would now make them a watcher
+        actors = {a.created_by for a in case.actions.filter(action__in=('O', 'R', 'N'))}
+
+        watchers = repliers.union(actors)
+
+        for user in watchers:
+            case.watchers.add(user)
+
+    if cases:
+        print("Populated watchers for %d cases" % len(cases))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cases', '0038_case_watchers'),
+        ('msgs', '0049_remove_label_tests'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_case_watchers)
+    ]

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -113,7 +113,6 @@ describe('services:', () ->
         $httpBackend.expectPOST('/case/close/501/', {note: "Hello there"}).respond('')
         CaseService.close(test.case1, "Hello there").then(() ->
           expect(test.case1.is_closed).toEqual(true)
-          expect(test.case1.watching).toEqual(true)
         )
         $httpBackend.flush()
       )
@@ -177,7 +176,6 @@ describe('services:', () ->
         $httpBackend.expectPOST('/case/update_summary/501/', {summary: "Got coffee?"}).respond('')
         CaseService.updateSummary(test.case1, "Got coffee?").then(() ->
           expect(test.case1.summary).toEqual("Got coffee?")
-          expect(test.case1.watching).toEqual(true)
         )
         $httpBackend.flush()
       )

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -265,7 +265,6 @@ services.factory('CaseService', ['$http', '$httpParamSerializer', '$window', ($h
     reassign: (caseObj, assignee) ->
       return $http.post('/case/reassign/' + caseObj.id + '/', {assignee: assignee.id}).then(() ->
         caseObj.assignee = assignee
-        caseObj.watching = true
       )
 
     #----------------------------------------------------------------------------
@@ -274,7 +273,6 @@ services.factory('CaseService', ['$http', '$httpParamSerializer', '$window', ($h
     close: (caseObj, note) ->
       return $http.post('/case/close/' + caseObj.id + '/', {note: note}).then(() ->
         caseObj.is_closed = true
-        caseObj.watching = true
       )
 
     #----------------------------------------------------------------------------
@@ -296,7 +294,6 @@ services.factory('CaseService', ['$http', '$httpParamSerializer', '$window', ($h
 
       return $http.post('/case/label/' + caseObj.id + '/', params).then(() ->
         caseObj.labels = labels
-        caseObj.watching = true
       )
 
     #----------------------------------------------------------------------------
@@ -305,7 +302,6 @@ services.factory('CaseService', ['$http', '$httpParamSerializer', '$window', ($h
     updateSummary: (caseObj, summary) ->
       return $http.post('/case/update_summary/' + caseObj.id + '/', {summary: summary}).then(() ->
         caseObj.summary = summary
-        caseObj.watching = true
       )
 
     #----------------------------------------------------------------------------


### PR DESCRIPTION
1. Adds migration to add users as watchers on existing cases
2. Case actions which automatically make the user a watcher now limited to:
 * Opening
 * Reopening
 * Adding a note
 * Replying