### PR TITLE
Track incoming messages by org and label

### DIFF
--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -308,8 +308,8 @@ class MessageTest(BaseCasesTest):
             setattr(message, '__data__labels', [("L-001", "Spam")])
             message.save()
 
-        # check removing a group and adding new ones
-        with self.assertNumQueries(6):
+        # check removing a label and adding new ones
+        with self.assertNumQueries(10):
             setattr(message, '__data__labels', [("L-002", "Feedback"), ("L-003", "Important")])
             message.save()
 

--- a/casepro/orgs_ext/views.py
+++ b/casepro/orgs_ext/views.py
@@ -38,6 +38,7 @@ class OrgExtCRUDL(SmartCRUDL):
 
         def get_summary(self, org):
             return {
+                'total_incoming': DailyCount.get_by_org([org], DailyCount.TYPE_INCOMING).total(),
                 'total_replies': DailyCount.get_by_org([org], DailyCount.TYPE_REPLIES).total(),
                 'cases_open': Case.objects.filter(org=org, closed_on=None).count(),
                 'cases_closed': Case.objects.filter(org=org).exclude(closed_on=None).count()

--- a/casepro/statistics/migrations/0003_auto_20160701_1412.py
+++ b/casepro/statistics/migrations/0003_auto_20160701_1412.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('statistics', '0002_populate_reply_counts'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='dailycount',
+            name='count',
+            field=models.IntegerField(),
+        ),
+    ]

--- a/casepro/statistics/migrations/0004_populate_incomining_counts.py
+++ b/casepro/statistics/migrations/0004_populate_incomining_counts.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import six
+
+from collections import defaultdict
+from django.db import migrations
+
+from dash.utils import chunks
+
+
+def populate_incoming_counts(apps, schema_editor):
+    Org = apps.get_model('orgs', 'Org')
+    Message = apps.get_model('msgs', 'Message')
+    DailyCount = apps.get_model('statistics', 'DailyCount')
+
+    for org in Org.objects.all():
+        print("Populating incoming counts for %s [%d]..." % (org.name, org.pk))
+
+        message_ids = list(org.incoming_messages.values_list('pk', flat=True))
+
+        print(" > Fetched ids of all %d org messages" % len(message_ids))
+
+        num_processed = 0
+
+        for id_batch in chunks(message_ids, 5000):
+            # extract this batch of messages with day and labels
+            messages = Message.objects.filter(pk__in=id_batch).prefetch_related('labels')
+            messages = list(messages.extra(select={'day': 'DATE(created_on)'}))
+
+            # organize into lists by day
+            messages_by_day = defaultdict(list)
+            for message in messages:
+                messages_by_day[message.day].append(message)
+
+            # process each day's messages
+            for day in sorted(messages_by_day.keys()):
+                day_messages = messages_by_day[day]
+
+                # record day count for org
+                org_count = len(day_messages)
+                DailyCount.objects.create(day=day, item_type='I', scope='org:%d' % org.pk, count=org_count)
+
+                # count labels for this day
+                label_counts = defaultdict(int)
+                for message in day_messages:
+                    for label in message.labels.all():
+                        label_counts[label] += 1
+
+                # record day count for labels
+                for label, label_count in six.iteritems(label_counts):
+                    DailyCount.objects.create(day=day, item_type='I', scope='label:%d' % label.pk, count=label_count)
+
+            num_processed += len(id_batch)
+            print("Processed %d of %d messages" % (num_processed, len(message_ids)))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('statistics', '0003_auto_20160701_1412'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_incoming_counts)
+    ]

--- a/casepro/statistics/signals.py
+++ b/casepro/statistics/signals.py
@@ -66,4 +66,3 @@ def record_incoming_labelling(sender, instance, action, reverse, model, pk_set, 
     elif action == 'pre_clear':
         for label in instance.labels.all():
             DailyCount.record_removal(day, DailyCount.TYPE_INCOMING, label)
-

--- a/casepro/statistics/signals.py
+++ b/casepro/statistics/signals.py
@@ -1,14 +1,69 @@
 from __future__ import unicode_literals
 
-from django.db.models.signals import post_save
+import pytz
+
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save, m2m_changed
 from django.dispatch import receiver
+from django.utils.functional import SimpleLazyObject
 
-from casepro.msgs.models import Outgoing
+from casepro.msgs.models import Message, Label, Outgoing
 
-from .models import record_new_outgoing
+from .models import DailyCount
+
+
+def datetime_to_date(dt, org):
+    """
+    Convert a datetime to a date using the given org's timezone
+    """
+    return dt.astimezone(pytz.timezone(org.timezone)).date()
+
+
+@receiver(post_save, sender=Message)
+def record_new_incoming(sender, instance, created, **kwargs):
+    """
+    Records a new outgoing being sent
+    """
+    if created:
+        org = instance.org
+
+        # get day in org timezone
+        day = datetime_to_date(instance.created_on, org)
+
+        DailyCount.record_item(day, DailyCount.TYPE_INCOMING, org)
 
 
 @receiver(post_save, sender=Outgoing)
-def record_outgoing_statistics(sender, instance, created, **kwargs):
-    if created:
-        record_new_outgoing(instance)
+def record_new_outgoing(sender, instance, created, **kwargs):
+    if created and instance.is_reply():
+        org = instance.org
+        partner = instance.partner
+        user = instance.created_by
+
+        if isinstance(user, SimpleLazyObject):
+            user = User.objects.get(pk=user.pk)
+
+        # get day in org timezone
+        day = datetime_to_date(instance.created_on, org)
+
+        DailyCount.record_item(day, DailyCount.TYPE_REPLIES, org)
+        DailyCount.record_item(day, DailyCount.TYPE_REPLIES, org, user)
+
+        if instance.partner:
+            DailyCount.record_item(day, DailyCount.TYPE_REPLIES, partner)
+
+
+@receiver(m2m_changed, sender=Message.labels.through)
+def record_incoming_labelling(sender, instance, action, reverse, model, pk_set, **kwargs):
+    day = datetime_to_date(instance.created_on, instance.org)
+
+    if action == 'post_add':
+        for label_id in pk_set:
+            DailyCount.record_item(day, DailyCount.TYPE_INCOMING, Label(pk=label_id))
+    elif action == 'post_remove':
+        for label_id in pk_set:
+            DailyCount.record_removal(day, DailyCount.TYPE_INCOMING, Label(pk=label_id))
+    elif action == 'pre_clear':
+        for label in instance.labels.all():
+            DailyCount.record_removal(day, DailyCount.TYPE_INCOMING, label)
+

--- a/casepro/statistics/tests.py
+++ b/casepro/statistics/tests.py
@@ -22,27 +22,38 @@ class DailyCountsTest(BaseCasesTest):
         self.ann = self.create_contact(self.unicef, 'C-001', "Ann")
         self.ned = self.create_contact(self.nyaruka, 'C-002', "Ned")
 
-        self._backend_id = 200
+        self._incoming_backend_id = 100
+        self._outgoing_backend_id = 200
 
-    def send_outgoing(self, user, day, count=1):
+    def new_messages(self, day, count=1):
         for m in range(count):
-            self._backend_id += 1
+            self._incoming_backend_id += 1
             hour = random.randrange(0, 24)
             minute = random.randrange(0, 60)
             created_on = pytz.timezone("Africa/Kampala").localize(datetime.combine(day, time(hour, minute, 0, 0)))
 
-            self.create_outgoing(self.unicef, user, self._backend_id, 'B', "Hello", self.ann, created_on=created_on)
+            self.create_message(self.unicef, self._incoming_backend_id, self.ann, "Hello", created_on=created_on)
 
-    def test_counts(self):
-        self.send_outgoing(self.admin, date(2015, 1, 1), count=2)
-        self.send_outgoing(self.user1, date(2015, 1, 1))
-        self.send_outgoing(self.user1, date(2015, 1, 2), count=2)
-        self.send_outgoing(self.user2, date(2015, 1, 2))
-        self.send_outgoing(self.user3, date(2015, 1, 3))
-        self.send_outgoing(self.user3, date(2015, 2, 1))
-        self.send_outgoing(self.user3, date(2015, 2, 2), count=2)
-        self.send_outgoing(self.user3, date(2015, 2, 28))
-        self.send_outgoing(self.user3, date(2015, 3, 1))
+    def new_outgoing(self, user, day, count=1):
+        for m in range(count):
+            self._outgoing_backend_id += 1
+            hour = random.randrange(0, 24)
+            minute = random.randrange(0, 60)
+            created_on = pytz.timezone("Africa/Kampala").localize(datetime.combine(day, time(hour, minute, 0, 0)))
+
+            self.create_outgoing(self.unicef, user, self._outgoing_backend_id, 'B', "Hello", self.ann,
+                                 created_on=created_on)
+
+    def test_reply_counts(self):
+        self.new_outgoing(self.admin, date(2015, 1, 1), count=2)
+        self.new_outgoing(self.user1, date(2015, 1, 1))
+        self.new_outgoing(self.user1, date(2015, 1, 2), count=2)
+        self.new_outgoing(self.user2, date(2015, 1, 2))
+        self.new_outgoing(self.user3, date(2015, 1, 3))
+        self.new_outgoing(self.user3, date(2015, 2, 1))
+        self.new_outgoing(self.user3, date(2015, 2, 2), count=2)
+        self.new_outgoing(self.user3, date(2015, 2, 28))
+        self.new_outgoing(self.user3, date(2015, 3, 1))
 
         self.create_outgoing(self.unicef, self.admin, 203, 'F', "Hello", self.ann,
                              created_on=datetime(2015, 1, 1, 11, 0, tzinfo=pytz.UTC))  # admin on Jan 1st (not a reply)
@@ -108,7 +119,7 @@ class DailyCountsTest(BaseCasesTest):
         self.assertEqual(DailyCount.objects.count(), 26)
 
         # add new count on day that already has a squashed value
-        self.send_outgoing(self.admin, date(2015, 1, 1))
+        self.new_outgoing(self.admin, date(2015, 1, 1))
 
         self.assertEqual(DailyCount.get_by_org([self.unicef], 'R').total(), 13)
 
@@ -118,6 +129,12 @@ class DailyCountsTest(BaseCasesTest):
         self.assertEqual(DailyCount.objects.count(), 26)
         self.assertEqual(DailyCount.get_by_org([self.unicef], 'R').total(), 13)
 
+    def test_incoming_counts(self):
+        self.new_messages(date(2015, 1, 1), count=2)
+        self.new_messages(date(2015, 1, 2), count=1)
+
+        self.assertEqual(DailyCount.get_by_org([self.unicef], 'I').total(), 3)
+
     def test_replies_chart(self):
         url = reverse('stats.replies_chart')
 
@@ -125,11 +142,11 @@ class DailyCountsTest(BaseCasesTest):
 
         self.login(self.user3)  # even users from other partners can see this
 
-        self.send_outgoing(self.admin, date(2016, 1, 1))  # Jan 1st
-        self.send_outgoing(self.user1, date(2016, 1, 15))  # Jan 15th
-        self.send_outgoing(self.user1, date(2016, 1, 20))  # Jan 20th
-        self.send_outgoing(self.user2, date(2016, 2, 1))  # Feb 1st
-        self.send_outgoing(self.user3, date(2016, 2, 1))  # different partner
+        self.new_outgoing(self.admin, date(2016, 1, 1))  # Jan 1st
+        self.new_outgoing(self.user1, date(2016, 1, 15))  # Jan 15th
+        self.new_outgoing(self.user1, date(2016, 1, 20))  # Jan 20th
+        self.new_outgoing(self.user2, date(2016, 2, 1))  # Feb 1st
+        self.new_outgoing(self.user3, date(2016, 2, 1))  # different partner
 
         # simulate making requests in April
         with patch.object(timezone, 'now', return_value=datetime(2016, 4, 20, 9, 0, tzinfo=pytz.UTC)):

--- a/templates/orgs_ext/org_home.haml
+++ b/templates/orgs_ext/org_home.haml
@@ -1,5 +1,5 @@
 - extends "smartmin/read.html"
-- load smartmin i18n thumbnail
+- load smartmin i18n thumbnail humanize
 
 - block pre-content
 
@@ -29,11 +29,13 @@
           .col-md-4
             %ul
               %li
-                Total replies: <strong>{{ summary.total_replies }}</strong>
+                Total messages: <strong>{{ summary.total_incoming | intcomma }}</strong>
               %li
-                Number of open cases: <strong>{{ summary.cases_open }}</strong>
+                Total replies: <strong>{{ summary.total_replies | intcomma }}</strong>
               %li
-                Number of closed cases: <strong>{{ summary.cases_closed }}</strong>
+                Number of open cases: <strong>{{ summary.cases_open | intcomma }}</strong>
+              %li
+                Number of closed cases: <strong>{{ summary.cases_closed | intcomma }}</strong>
           .col-md-8
             #chart-replies-by-month
       </uib-tab>


### PR DESCRIPTION
Keeps track of number of incoming messages received each day using `DailyCount`. If labels on existing messages are manually changed after message is received, counts are updated accordingly.