### PR TITLE
Simple label dashboard

### DIFF
--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -429,7 +429,7 @@ class Case(models.Model):
                 'id': self.pk,
                 'assignee': self.assignee.as_json(),
                 'contact': self.contact.as_json(full=False),
-                'labels': [l.as_json() for l in self.labels.all()],
+                'labels': [l.as_json(full=False) for l in self.labels.all()],
                 'summary': self.summary,
                 'opened_on': self.opened_on,
                 'is_closed': self.is_closed

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -92,9 +92,6 @@ class Label(models.Model):
     def lock(cls, org, uuid):
         return get_redis_connection().lock(LABEL_LOCK_KEY % (org.pk, uuid), timeout=60)
 
-    def get_partners(self):
-        return self.partners.filter(is_active=True)
-
     def release(self):
         rule = self.rule
 

--- a/casepro/msgs/models.py
+++ b/casepro/msgs/models.py
@@ -105,8 +105,14 @@ class Label(models.Model):
         if rule:
             rule.delete()
 
-    def as_json(self):
-        return {'id': self.pk, 'name': self.name}
+    def as_json(self, full=True):
+        result = {'id': self.pk, 'name': self.name}
+
+        if full:
+            result['description'] = self.description
+            result['synced'] = self.is_synced
+
+        return result
 
     def __str__(self):
         return self.name
@@ -345,7 +351,7 @@ class Message(models.Model):
             'contact': self.contact.as_json(full=False),
             'text': self.text,
             'time': self.created_on,
-            'labels': [l.as_json() for l in self.labels.all()],
+            'labels': [l.as_json(full=False) for l in self.labels.all()],
             'flagged': self.is_flagged,
             'archived': self.is_archived,
             'direction': self.DIRECTION,

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -200,6 +200,27 @@ class LabelCRUDLTest(BaseCasesTest):
         self.assertEqual(self.unicef.labels.count(), 3)
         self.assertEqual(self.unicef.rules.count(), 2)
 
+    def test_read(self):
+        url = reverse('msgs.label_read', args=[self.pregnancy.pk])
+
+        # log in as an administrator
+        self.login(self.admin)
+
+        response = self.url_get('unicef', url)
+        self.assertEqual(response.status_code, 200)
+
+        # log in as partner user with access to this label
+        self.login(self.user1)
+
+        response = self.url_get('unicef', url)
+        self.assertEqual(response.status_code, 200)
+
+        # log in as partner user without access to this label
+        self.login(self.user3)
+
+        response = self.url_get('unicef', url)
+        self.assertEqual(response.status_code, 404)
+
     def test_list(self):
         url = reverse('msgs.label_list')
 

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -229,7 +229,20 @@ class LabelCRUDLTest(BaseCasesTest):
 
         response = self.url_get('unicef', url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(response.context['object_list']), [self.aids, self.pregnancy, self.tea])
+        self.assertEqual(response.json['results'], [
+            {'id': self.aids.pk, 'name': "AIDS", 'description': "Messages about AIDS", 'synced': True},
+            {'id': self.pregnancy.pk, 'name': "Pregnancy", 'description': "Messages about pregnancy", 'synced': True},
+            {'id': self.tea.pk, 'name': "Tea", 'description': "Messages about tea", 'synced': False}
+        ])
+
+        response = self.url_get('unicef', url + "?with_activity=true")
+        self.assertEqual(response.json['results'][0], {
+            'id': self.aids.pk,
+            'name': "AIDS",
+            'description': "Messages about AIDS",
+            'synced': True,
+            'messages': {'this_month': 0, 'last_month': 0}
+        })
 
     def test_delete(self):
         url = reverse('msgs.label_delete', args=[self.pregnancy.pk])

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -378,7 +378,7 @@ class OutgoingCRUDL(SmartCRUDL):
                     'reply_to': {
                         'text': msg.reply_to.text,
                         'flagged': msg.reply_to.is_flagged,
-                        'labels': [l.as_json() for l in msg.reply_to.labels.all()],
+                        'labels': [l.as_json(full=False) for l in msg.reply_to.labels.all()],
                     },
                     'response': {
                         'delay': timesince(msg.reply_to.created_on, now=msg.created_on),

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -305,7 +305,7 @@ PERMISSIONS = {
 
     'orgs.org': ('create', 'update', 'list', 'home', 'edit', 'inbox', 'charts'),
 
-    'msgs.label': ('create', 'update', 'list'),
+    'msgs.label': ('create', 'update', 'read', 'delete', 'list'),
 
     'msgs.message': ('action', 'bulk_reply', 'forward', 'label', 'history', 'search', 'unlabelled'),
 
@@ -359,6 +359,7 @@ GROUP_PERMISSIONS = {
         'orgs.org_inbox',
         'orgs.org_charts',
 
+        'msgs.label_read',
         'msgs.message_action',
         'msgs.message_bulk_reply',
         'msgs.message_forward',
@@ -393,6 +394,7 @@ GROUP_PERMISSIONS = {
         'orgs.org_inbox',
         'orgs.org_charts',
 
+        'msgs.label_read',
         'msgs.message_action',
         'msgs.message_bulk_reply',
         'msgs.message_forward',

--- a/casepro/statistics/models.py
+++ b/casepro/statistics/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import pytz
 import six
 
 from dash.orgs.models import Org
@@ -11,6 +12,13 @@ from django.utils.translation import ugettext_lazy as _
 
 from casepro.cases.models import Partner
 from casepro.msgs.models import Label
+
+
+def datetime_to_date(dt, org):
+    """
+    Convert a datetime to a date using the given org's timezone
+    """
+    return dt.astimezone(pytz.timezone(org.timezone)).date()
 
 
 class DailyCount(models.Model):

--- a/casepro/statistics/signals.py
+++ b/casepro/statistics/signals.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import pytz
-
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save, m2m_changed
 from django.dispatch import receiver
@@ -9,14 +7,7 @@ from django.utils.functional import SimpleLazyObject
 
 from casepro.msgs.models import Message, Label, Outgoing
 
-from .models import DailyCount
-
-
-def datetime_to_date(dt, org):
-    """
-    Convert a datetime to a date using the given org's timezone
-    """
-    return dt.astimezone(pytz.timezone(org.timezone)).date()
+from .models import datetime_to_date, DailyCount
 
 
 @receiver(post_save, sender=Message)

--- a/casepro/statistics/urls.py
+++ b/casepro/statistics/urls.py
@@ -2,8 +2,9 @@ from __future__ import unicode_literals
 
 from django.conf.urls import url
 
-from .views import RepliesPerMonthChart
+from .views import IncomingPerDayChart, RepliesPerMonthChart
 
 urlpatterns = [
+    url(r'^incoming_chart/$', IncomingPerDayChart.as_view(), name='stats.incoming_chart'),
     url(r'^replies_chart/$', RepliesPerMonthChart.as_view(), name='stats.replies_chart'),
 ]

--- a/casepro/utils/__init__.py
+++ b/casepro/utils/__init__.py
@@ -1,13 +1,13 @@
 from __future__ import unicode_literals
 
 import calendar
-import datetime
 import json
 import pytz
 import re
 import unicodedata
 
 from dateutil.relativedelta import relativedelta
+from datetime import datetime, time
 from django.utils import timezone
 from enum import Enum
 from temba_client.utils import format_iso8601
@@ -37,7 +37,7 @@ class JSONEncoder(json.JSONEncoder):
     JSON encoder which encodes datetime values as strings
     """
     def default(self, val):
-        if isinstance(val, datetime.datetime):
+        if isinstance(val, datetime):
             return format_iso8601(val)
         elif isinstance(val, Enum):
             return val.name
@@ -95,6 +95,13 @@ def truncate(text, length=100, suffix='...'):
         return text
 
 
+def date_to_milliseconds(d):
+    """
+    Converts a date to a millisecond accuracy timestamp. Equivalent to Date.UTC(d.year, d.month-1, d.day) in Javascript
+    """
+    return calendar.timegm(datetime.combine(d, time(0, 0, 0)).replace(tzinfo=pytz.UTC).utctimetuple()) * 1000
+
+
 def datetime_to_microseconds(dt):
     """
     Converts a datetime to a microsecond accuracy timestamp
@@ -107,7 +114,7 @@ def microseconds_to_datetime(ms):
     """
     Converts a microsecond accuracy timestamp to a datetime
     """
-    return datetime.datetime.utcfromtimestamp(ms / 1000000.0).replace(tzinfo=pytz.utc)
+    return datetime.utcfromtimestamp(ms / 1000000.0).replace(tzinfo=pytz.utc)
 
 
 def month_range(offset, now=None):

--- a/casepro/utils/tests.py
+++ b/casepro/utils/tests.py
@@ -12,7 +12,7 @@ from enum import Enum
 from casepro.test import BaseCasesTest
 
 from . import safe_max, normalize, match_keywords, truncate, str_to_bool, json_encode
-from . import datetime_to_microseconds, microseconds_to_datetime, month_range
+from . import date_to_milliseconds, datetime_to_microseconds, microseconds_to_datetime, month_range
 from .email import send_email
 from .middleware import JSONMiddleware
 
@@ -56,6 +56,10 @@ class UtilsTest(BaseCasesTest):
         self.assertTrue(str_to_bool("TrUE"))
         self.assertTrue(str_to_bool("Y"))
         self.assertTrue(str_to_bool("YeS"))
+
+    def test_date_to_milliseconds(self):
+        self.assertEqual(date_to_milliseconds(date(2015, 1, 1)), 1420070400000)
+        self.assertEqual(date_to_milliseconds(date(2015, 2, 1)), 1422748800000)
 
     def test_microseconds_to_datetime(self):
         d1 = datetime(2015, 10, 9, 14, 48, 30, 123456, tzinfo=pytz.utc).astimezone(pytz.timezone("Africa/Kigali"))

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -425,7 +425,7 @@ controllers.controller('CasesController', ['$scope', '$timeout', '$controller', 
 #============================================================================
 # Org home controller
 #============================================================================
-controllers.controller('HomeController', ['$scope', '$controller', 'PartnerService', 'StatisticsService', 'UserService', ($scope, $controller, PartnerService, StatisticsService, UserService) ->
+controllers.controller('HomeController', ['$scope', '$controller', 'LabelService', 'PartnerService', 'StatisticsService', 'UserService', ($scope, $controller, LabelService, PartnerService, StatisticsService, UserService) ->
   $controller('BaseTabsController', {$scope: $scope})
 
   $scope.partners = []
@@ -447,6 +447,10 @@ controllers.controller('HomeController', ['$scope', '$controller', 'PartnerServi
     else if tab == 'partners'
       PartnerService.fetchAll(true).then((partners) ->
         $scope.partners = partners
+      )
+    else if tab == 'labels'
+      LabelService.fetchAll(true).then((labels) ->
+        $scope.labels = labels
       )
     else if tab == 'users'
       UserService.fetchNonPartner(true).then((users) ->

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -406,6 +406,15 @@ services.factory('StatisticsService', ['$http', '$httpParamSerializer', ($http, 
   new class StatisticsService
 
     #----------------------------------------------------------------------------
+    # Fetches data for incoming by day chart
+    #----------------------------------------------------------------------------
+    incomingChart: (label = null) ->
+      params = {
+        label: if label then label.id else null,
+      }
+      return $http.get('/stats/incoming_chart/?' + $httpParamSerializer(params)).then((response) -> response.data)
+
+    #----------------------------------------------------------------------------
     # Fetches data for replies by month chart
     #----------------------------------------------------------------------------
     repliesChart: (partner = null, user = null) ->

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -361,8 +361,15 @@ services.factory('CaseService', ['$http', '$httpParamSerializer', '$window', ($h
 # Label service
 #=====================================================================
 
-services.factory('LabelService', ['$http', ($http) ->
+services.factory('LabelService', ['$http', '$httpParamSerializer', ($http, $httpParamSerializer) ->
   new class LabelService
+
+    #----------------------------------------------------------------------------
+    # Fetches all labels, optionally with activity information
+    #----------------------------------------------------------------------------
+    fetchAll: (withActivity = false) ->
+      params = {with_activity: withActivity}
+      return $http.get('/label/?' + $httpParamSerializer(params)).then((response) -> response.data.results)
 
     #----------------------------------------------------------------------------
     # Deletes a label

--- a/templates/cases/inbox_base.haml
+++ b/templates/cases/inbox_base.haml
@@ -26,14 +26,10 @@
           %span.glyphicon.glyphicon-tag
           &nbsp;
           [[ activeLabel.name ]]
-        - if org_perms.msgs.label_update or org_perms.msgs.label_delete
-          .btn-group
-            - if org_perms.msgs.label_update
-              %a.btn.btn-default{ ng-href:"/label/update/[[ activeLabel.id ]]/", tooltip:"Edit Label" }
-                %span.glyphicon.glyphicon-pencil
-            - if org_perms.msgs.label_delete
-              %button.btn.btn-default{ ng-click:"onDeleteLabel()", tooltip:"Delete Label" }
-                %span.glyphicon.glyphicon-trash
+        - if perms.msgs.label_read or org_perms.msgs.label_read
+          %a.btn.btn-default{ ng-href:"/label/read/[[ activeLabel.id ]]/" }
+            - trans "View"
+
 
     .row
       .col-md-2

--- a/templates/cases/partner_read.haml
+++ b/templates/cases/partner_read.haml
@@ -1,5 +1,5 @@
 - extends "smartmin/read.html"
-- load smartmin i18n thumbnail
+- load smartmin i18n thumbnail humanize
 
 - block pre-content
 
@@ -52,11 +52,11 @@
           .col-md-4
             %ul
               %li
-                Total replies: <strong>{{ summary.total_replies }}</strong>
+                Total replies: <strong>{{ summary.total_replies | intcomma }}</strong>
               %li
-                Number of open cases: <strong>{{ summary.cases_open }}</strong>
+                Number of open cases: <strong>{{ summary.cases_open | intcomma }}</strong>
               %li
-                Number of closed cases: <strong>{{ summary.cases_closed }}</strong>
+                Number of closed cases: <strong>{{ summary.cases_closed | intcomma }}</strong>
           .col-md-8
             #chart-replies-by-month
       </uib-tab>

--- a/templates/frame.haml
+++ b/templates/frame.haml
@@ -85,11 +85,6 @@
                       - trans "Administration"
                       %b.caret
                     %ul.dropdown-menu
-                      - if perms.msgs.label_list or org_perms.msgs.label_list
-                        %li
-                          %a{ href:"{% url 'msgs.label_list' %}" }
-                            - trans "Labels"
-
                       - if perms.contacts.group_list or org_perms.contacts.group_list
                         %li
                           %a{ href:"{% url 'contacts.group_list' %}" }

--- a/templates/msgs/label_read.haml
+++ b/templates/msgs/label_read.haml
@@ -1,0 +1,54 @@
+- extends "smartmin/read.html"
+- load smartmin i18n thumbnail humanize
+
+- block pre-content
+
+- block content
+
+  %script{ type:"text/javascript" }
+    var contextData = {{ context_data_json|safe }};
+
+  .ng-cloak{ ng-controller:"LabelController", ng-init:"init()", ng-cloak:"" }
+    .page-header.clearfix{ style:"border-bottom: none" }
+      .clearfix{ style:"margin-bottom: 10px" }
+        .page-header-buttons
+          - if perms.msgs.label_update or org_perms.msgs.label_update
+            .btn-group
+              %a.btn.btn-default{ href:"{% url 'msgs.label_update' object.pk %}", tooltip:"Edit Label" }
+                %i.glyphicon.glyphicon-pencil
+              - if perms.msgs.label_delete or org_perms.msgs.label_delete
+                %a.btn.btn-default{ ng-click:"onDeleteLabel()", tooltip:"Delete" }
+                  %i.glyphicon.glyphicon-trash
+
+        %h2
+          {{ object.name }}
+
+        .
+          {{ object.description }}
+
+    <uib-tabset active="active">
+
+      <uib-tab index="0" select="onTabSelect('summary')">
+        <uib-tab-heading>
+          %i.glyphicon.glyphicon-dashboard
+          - trans "Summary"
+        </uib-tab-heading>
+        %br
+        .row
+          .col-md-4
+            %ul
+              %li
+                Total messages: <strong>{{ summary.total_messages | intcomma }}</strong>
+          .col-md-8
+            #chart-incoming-by-day
+      </uib-tab>
+    </uib-tabset>
+
+
+- block extra-style
+  {{ block.super }}
+  :css
+    #chart-incoming-by-day {
+      width: 100%;
+      height: 250px;
+    }

--- a/templates/orgs_ext/org_home.haml
+++ b/templates/orgs_ext/org_home.haml
@@ -79,7 +79,42 @@
 
       </uib-tab>
 
-      <uib-tab index="2" select="onTabSelect('users')">
+      <uib-tab index="2" select="onTabSelect('labels')">
+        <uib-tab-heading>
+          %i.glyphicon.glyphicon-tags{ style:"margin-right: 4px" }
+          - trans "Labels"
+        </uib-tab-heading>
+        .search-toolbar.clearfix
+          - if perms.msgs.label_create or org_perms.msgs.label_create
+            .pull-away
+              <a class="btn btn-default" href="{% url 'msgs.label_create' %}">{% trans "New..." %}</a>
+
+          .{ style:"margin-top: 7px" }
+            Total of <strong>[[ labels.length ]]</strong> labels
+
+        %table.table.table-striped
+          %thead
+            %th
+              - trans "Name"
+            %th
+              - trans "Messages (this month)"
+            %th
+              - trans "Messages (last month)"
+          %tbody
+            %tr{ ng-repeat:"label in labels" }
+              %td
+                %a{ ng-href:"/label/read/[[ label.id ]]/" }><
+                  [[ label.name ]]
+              %td
+                [[ label.messages.this_month ]]
+              %td
+                [[ label.messages.last_month ]]
+        .none{ ng-if:"!labels" }
+          - trans "None"
+
+      </uib-tab>
+
+      <uib-tab index="3" select="onTabSelect('users')">
         <uib-tab-heading>
           %span.glyphicon.glyphicon-user
           - trans "Users"


### PR DESCRIPTION
Replaces label list page with new Labels tab on org dashboard:

<img width="990" alt="screen shot 2016-07-06 at 16 59 25" src="https://cloud.githubusercontent.com/assets/675558/16622642/21c1c0ea-439b-11e6-8c6a-6c900fcd084d.png">

Clicking on a label takes user to new label dashboard. For now just has simple summary but from here users can edit/delete the label - and after subsequent PR - this is where they will also watch/unwatch a label.

<img width="988" alt="screen shot 2016-07-06 at 16 59 53" src="https://cloud.githubusercontent.com/assets/675558/16622643/22b69cd2-439b-11e6-9077-28a4f81c7d39.png">
