### PR TITLE
Reflect tab changes in url so that specific tabs can be linked to

### DIFF
--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -527,6 +527,59 @@ describe('controllers:', () ->
   )
 
   #=======================================================================
+  # Tests for HomeController
+  #=======================================================================
+  describe('HomeController', () ->
+    StatisticsService = null
+    PartnerService = null
+    LabelService = null
+    UserService = null
+    $scope = null
+
+    beforeEach(inject((_StatisticsService_, _PartnerService_, _LabelService_, _UserService_) ->
+      StatisticsService = _StatisticsService_
+      PartnerService = _PartnerService_
+      LabelService = _LabelService_
+      UserService = _UserService_
+
+      $scope = $rootScope.$new()
+      $controller('HomeController', {$scope: $scope})
+    ))
+
+    it('onTabSelect', () ->
+      repliesChart = spyOnPromise($q, $scope, StatisticsService, 'repliesChart')
+      fetchPartners = spyOnPromise($q, $scope, PartnerService, 'fetchAll')
+      fetchLabels = spyOnPromise($q, $scope, LabelService, 'fetchAll')
+      fetchUsers = spyOnPromise($q, $scope, UserService, 'fetchNonPartner')
+
+      $scope.onTabSelect(0)
+
+      expect(StatisticsService.repliesChart).toHaveBeenCalledWith()
+
+      $scope.onTabSelect(1)
+
+      partners = [test.moh, test.who]
+      fetchPartners.resolve(partners)
+
+      expect($scope.partners).toEqual(partners)
+
+      $scope.onTabSelect(2)
+
+      labels = [test.tea, test.coffee]
+      fetchLabels.resolve(labels)
+
+      expect($scope.labels).toEqual(labels)
+
+      $scope.onTabSelect(3)
+
+      users = [{id: 101, name: "Tom McTicket", replies: {last_month: 5, this_month: 10, total: 20}}]
+      fetchUsers.resolve(users)
+
+      expect($scope.users).toEqual(users)
+    )
+  )
+
+  #=======================================================================
   # Tests for PartnerController
   #=======================================================================
   describe('PartnerController', () ->
@@ -552,25 +605,25 @@ describe('controllers:', () ->
       fetchUsers = spyOnPromise($q, $scope, UserService, 'fetchInPartner')
       repliesChart = spyOnPromise($q, $scope, StatisticsService, 'repliesChart')
 
-      $scope.onTabSelect('summary')
+      $scope.onTabSelect(0)
 
       expect(StatisticsService.repliesChart).toHaveBeenCalledWith(test.moh, null)
-      expect($scope.initialisedTabs).toEqual(['summary'])
+      expect($scope.initialisedTabs).toEqual([0])
 
-      $scope.onTabSelect('users')
+      $scope.onTabSelect(2)
 
       users = [{id: 101, name: "Tom McTicket", replies: {last_month: 5, this_month: 10, total: 20}}]
       fetchUsers.resolve(users)
 
       expect($scope.users).toEqual(users)
-      expect($scope.initialisedTabs).toEqual(['summary', 'users'])
+      expect($scope.initialisedTabs).toEqual([0, 2])
 
       # select the users tab again
-      $scope.onTabSelect('users')
+      $scope.onTabSelect(2)
 
       # users shouldn't be re-fetched
       expect(UserService.fetchInPartner.calls.count()).toEqual(1)
-      expect($scope.initialisedTabs).toEqual(['summary', 'users'])
+      expect($scope.initialisedTabs).toEqual([0, 2])
     )
 
     it('onDeletePartner', () ->

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -73,13 +73,23 @@ controllers.controller('InboxController', ['$scope', '$window', '$location', 'La
 #============================================================================
 # Base controller class for controllers which have tabs
 #============================================================================
-controllers.controller('BaseTabsController', ['$scope', ($scope) ->
-
+controllers.controller('BaseTabsController', ['$scope', '$location', ($scope, $location) ->
   $scope.initialisedTabs = []
 
+  path = $location.path()
+  if path
+    initialTabSlug = path.substring(1)  # ignore initial /
+    $scope.active = $scope.tabSlugs.indexOf(initialTabSlug)
+  else
+    $scope.active = 0
+
   $scope.onTabSelect = (tab) ->
+    slug = $scope.tabSlugs[tab]
+
+    $location.path('/' + slug)
+
     if tab not in $scope.initialisedTabs
-      $scope.onTabInit(tab)
+      $scope.onTabInit(slug)
       $scope.initialisedTabs.push(tab)
 ])
 
@@ -426,6 +436,8 @@ controllers.controller('CasesController', ['$scope', '$timeout', '$controller', 
 # Org home controller
 #============================================================================
 controllers.controller('HomeController', ['$scope', '$controller', 'LabelService', 'PartnerService', 'StatisticsService', 'UserService', ($scope, $controller, LabelService, PartnerService, StatisticsService, UserService) ->
+  $scope.tabSlugs = ['summary', 'partners', 'labels', 'users']
+
   $controller('BaseTabsController', {$scope: $scope})
 
   $scope.partners = []
@@ -599,6 +611,8 @@ controllers.controller('CaseTimelineController', ['$scope', '$timeout', 'CaseSer
 # Label dashboard controller
 #============================================================================
 controllers.controller('LabelController', ['$scope', '$window', '$controller', 'UtilsService', 'LabelService', 'StatisticsService', ($scope, $window, $controller, UtilsService, LabelService, StatisticsService) ->
+  $scope.tabSlugs = ['summary']
+  
   $controller('BaseTabsController', {$scope: $scope})
 
   $scope.label = $window.contextData.label
@@ -639,6 +653,8 @@ controllers.controller('LabelController', ['$scope', '$window', '$controller', '
 # Partner dashboard controller
 #============================================================================
 controllers.controller('PartnerController', ['$scope', '$window', '$controller', 'UtilsService', 'PartnerService', 'StatisticsService', 'UserService', ($scope, $window, $controller, UtilsService, PartnerService, StatisticsService, UserService) ->
+  $scope.tabSlugs = ['summary', 'replies', 'users']
+
   $controller('BaseTabsController', {$scope: $scope})
 
   $scope.partner = $window.contextData.partner

--- a/templates/cases/partner_read.haml
+++ b/templates/cases/partner_read.haml
@@ -42,7 +42,7 @@
 
     <uib-tabset active="active">
 
-      <uib-tab index="0" select="onTabSelect('summary')">
+      <uib-tab index="0" select="onTabSelect(0)">
         <uib-tab-heading>
           %span.glyphicon.glyphicon-dashboard
           - trans "Summary"
@@ -62,7 +62,7 @@
       </uib-tab>
 
       - if can_view_replies
-        <uib-tab index="1" select="onTabSelect('replies')">
+        <uib-tab index="1" select="onTabSelect(1)">
           <uib-tab-heading>
             %span.glyphicon.glyphicon-comment
             - trans "Replies"
@@ -143,7 +143,7 @@
               - trans "More items than can be displayed"
         </uib-tab>
 
-      <uib-tab index="2" select="onTabSelect('users')">
+      <uib-tab index="2" select="onTabSelect(2)">
         <uib-tab-heading>
           %span.glyphicon.glyphicon-user
           - trans "Users"

--- a/templates/msgs/label_read.haml
+++ b/templates/msgs/label_read.haml
@@ -34,7 +34,7 @@
 
     <uib-tabset active="active">
 
-      <uib-tab index="0" select="onTabSelect('summary')">
+      <uib-tab index="0" select="onTabSelect(0)">
         <uib-tab-heading>
           %i.glyphicon.glyphicon-dashboard
           - trans "Summary"

--- a/templates/orgs_ext/org_home.haml
+++ b/templates/orgs_ext/org_home.haml
@@ -19,7 +19,7 @@
 
     <uib-tabset active="active">
 
-      <uib-tab index="0" select="onTabSelect('summary')">
+      <uib-tab index="0" select="onTabSelect(0)">
         <uib-tab-heading>
           %span.glyphicon.glyphicon-dashboard
           - trans "Summary"
@@ -40,7 +40,7 @@
             #chart-replies-by-month
       </uib-tab>
 
-      <uib-tab index="1" select="onTabSelect('partners')">
+      <uib-tab index="1" select="onTabSelect(1)">
         <uib-tab-heading>
           %span.glyphicon.glyphicon-th-large
           - trans "Partners"
@@ -79,7 +79,7 @@
 
       </uib-tab>
 
-      <uib-tab index="2" select="onTabSelect('labels')">
+      <uib-tab index="2" select="onTabSelect(2)">
         <uib-tab-heading>
           %i.glyphicon.glyphicon-tags{ style:"margin-right: 4px" }
           - trans "Labels"
@@ -114,7 +114,7 @@
 
       </uib-tab>
 
-      <uib-tab index="3" select="onTabSelect('users')">
+      <uib-tab index="3" select="onTabSelect(3)">
         <uib-tab-heading>
           %span.glyphicon.glyphicon-user
           - trans "Users"


### PR DESCRIPTION
For example, the URL `/org/home/#/labels` now goes directly to the labels tab on the org dashboard