### PR TITLE
Display label names with underscores as spaces in inbox

### DIFF
--- a/karma/test-filters.coffee
+++ b/karma/test-filters.coffee
@@ -42,4 +42,11 @@ describe('filters:', () ->
       expect(urlencode("A & B ?")).toEqual("A%20%26%20B%20%3F")
     )
   )
+
+  describe('deunderscore', () ->
+    it('replaces underscores with spaces', () ->
+      deunderscore = $filter('deunderscore')
+      expect(deunderscore("A_B__C_")).toEqual("A B  C ")
+    )
+  )
 )

--- a/static/coffee/filters.coffee
+++ b/static/coffee/filters.coffee
@@ -32,3 +32,12 @@ filters.filter('urlencode', ['$window', ($window) ->
   return (input) ->
     return $window.encodeURIComponent(input)
 ])
+
+
+#----------------------------------------------------------------------------
+# Replaces underscores with spaces
+#----------------------------------------------------------------------------
+filters.filter('deunderscore', () ->
+    return (input) ->
+        return input.replace(/_/g, ' ')
+)

--- a/templates/cases/inbox_base.haml
+++ b/templates/cases/inbox_base.haml
@@ -24,7 +24,7 @@
         .{ ng-if:"activeLabel" }
           %i.glyphicon.glyphicon-tag
           &nbsp;
-          [[ activeLabel.name ]]
+          [[ activeLabel.name | deunderscore ]]
 
       .page-header-buttons{ ng-if:"activeLabel" }
         - if perms.msgs.label_read or org_perms.msgs.label_read
@@ -46,7 +46,7 @@
                 %li.label-link{ ng-repeat:"label in labels" }
                   %a{ ng-href:"/#?label=[[ label.name | urlencode ]]", ng-class:'{ strong: label == activeLabel }' }
                     %span.glyphicon.glyphicon-tag{ style:"font-size: 0.75em" }
-                    [[ label.name ]] ([[ label.counts.inbox ]])
+                    [[ label.name | deunderscore ]] ([[ label.counts.inbox ]])
             %li{ class:"{% if_url 'cases.flagged' 'active' '' %}" }
               %a{ href:"{% url 'cases.flagged' %}" }
                 - trans "Flagged"


### PR DESCRIPTION
To allow wrapping of long label names, e.g.

<img width="323" alt="screen shot 2016-07-18 at 11 11 55" src="https://cloud.githubusercontent.com/assets/675558/16910383/a640e0a8-4cd8-11e6-8369-762ac6632c53.png">
<img width="320" alt="screen shot 2016-07-18 at 11 12 48" src="https://cloud.githubusercontent.com/assets/675558/16910385/a75bee88-4cd8-11e6-9e16-6b910dbde127.png">

