### PR TITLE
Simpler timeline rendering 

### DIFF
--- a/casepro/backend/__init__.py
+++ b/casepro/backend/__init__.py
@@ -195,8 +195,7 @@ class BaseBackend(object):
         :param contact: the contact
         :param created_after: include messages created after this time
         :param created_before: include messages created before this time
-        :return: the messages as JSON objects in reverse chronological order. JSON format should match that returned by
-                 Message.as_json() for incoming messages and Outgoing.as_json() for outgoing messages.
+        :return: the messages as transient Message and Outgoing instances
         """
 
 

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -325,23 +325,12 @@ class RapidProBackend(BaseBackend):
         """
         Used to grab messages sent to the contact from RapidPro that we won't have in CasePro
         """
-        contact_json = contact.as_json(full=False)
-
         # fetch remote messages for contact
         client = self._get_client(org, 2)
         remote_messages = client.get_messages(contact=contact.uuid, after=created_after, before=created_before).all()
 
-        def remote_as_json(msg):
-            # should match schema of Outgoing.as_json()
-            return {
-                'id': msg.broadcast,
-                'contact': contact_json,
-                'urn': None,
-                'text': msg.text,
-                'time': msg.created_on,
-                'direction': Outgoing.DIRECTION,
-                'case': None,
-                'sender': None
-            }
+        def remote_as_outgoing(msg):
+            return Outgoing(backend_broadcast_id=msg.broadcast, contact=contact, text=msg.text,
+                            created_on=msg.created_on)
 
-        return [remote_as_json(m) for m in remote_messages if m.direction == 'out']
+        return [remote_as_outgoing(m) for m in remote_messages if m.direction == 'out']

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -15,7 +15,7 @@ from temba_client.v2.types import Contact as TembaContact, Message as TembaMessa
 from unittest import skip
 
 from casepro.contacts.models import Contact, Field, Group
-from casepro.msgs.models import Label, Message
+from casepro.msgs.models import Label, Message, Outgoing
 from casepro.test import BaseCasesTest
 
 from ..rapidpro import RapidProBackend, ContactSyncer, MessageSyncer
@@ -825,22 +825,12 @@ class RapidProBackendTest(BaseCasesTest):
 
         messages = self.backend.fetch_contact_messages(self.unicef, self.ann, d1, d3)
 
-        self.assertEqual(messages, [
-            {
-                'id': 201,  # id is the broadcast id
-                'contact': {'id': self.ann.pk, 'name': "Ann"},
-                'urn': None,
-                'text': "Welcome",
-                'time': d3,
-                'direction': 'O',
-                'case': None,
-                'sender': None,
-            }
-        ])
-
-        # check that JSON schemas match local outgoing model
-        outgoing = self.create_outgoing(self.unicef, self.admin, 201, 'B', "Hello", self.ann)
-        self.assertEqual(messages[0].keys(), outgoing.as_json().keys())
+        self.assertEqual(len(messages), 1)
+        self.assertIsInstance(messages[0], Outgoing)
+        self.assertEqual(messages[0].backend_broadcast_id, 201)
+        self.assertEqual(messages[0].contact, self.ann)
+        self.assertEqual(messages[0].text, "Welcome")
+        self.assertEqual(messages[0].created_on, d3)
 
 
 @skip

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -15,6 +15,7 @@ from django_redis import get_redis_connection
 from casepro.backend import get_backend
 from casepro.contacts.models import Contact
 from casepro.msgs.models import Label, Message, Outgoing
+from casepro.utils import TimelineItem
 from casepro.utils.export import BaseSearchExport
 
 
@@ -259,8 +260,7 @@ class Case(models.Model):
         local_incoming = local_incoming.order_by('-created_on')
 
         # merge local incoming and outgoing
-        local_messages = chain(local_outgoing, local_incoming)
-        messages = [{'time': msg.created_on, 'type': 'M', 'item': msg.as_json()} for msg in local_messages]
+        timeline = [TimelineItem(msg) for msg in chain(local_outgoing, local_incoming)]
 
         if merge_from_backend:
             # if this is the initial request, fetch additional messages from the backend
@@ -272,16 +272,16 @@ class Case(models.Model):
                 local_broadcast_ids = {o.backend_broadcast_id for o in local_outgoing if o.backend_broadcast_id}
 
                 for msg in backend_messages:
-                    if msg['id'] not in local_broadcast_ids:
-                        messages.append({'time': msg['time'], 'type': 'M', 'item': msg})
+                    if msg.backend_broadcast_id not in local_broadcast_ids:
+                        timeline.append(TimelineItem(msg))
 
-        # fetch actions in chronological order
+        # fetch and append actions
         actions = self.actions.filter(created_on__gte=after, created_on__lte=before)
-        actions = actions.select_related('assignee', 'created_by').order_by('pk')
-        actions = [{'time': a.created_on, 'type': 'A', 'item': a.as_json()} for a in actions]
+        actions = actions.select_related('assignee', 'created_by')
+        timeline += [TimelineItem(a) for a in actions]
 
-        # merge actions and messages and sort by time
-        return sorted(messages + actions, key=lambda event: event['time'])
+        # sort timeline by reverse chronological order
+        return sorted(timeline, key=lambda item: item.get_time())
 
     def add_reply(self, message):
         message.case = self
@@ -461,6 +461,8 @@ class CaseAction(models.Model):
                       (UNLABEL, _("Remove Label")),
                       (CLOSE, _("Close")),
                       (REOPEN, _("Reopen")))
+
+    TIMELINE_TYPE = 'A'
 
     case = models.ForeignKey(Case, related_name="actions")
 

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -654,16 +654,8 @@ class CaseCRUDLTest(BaseCasesTest):
         CaseAction.create(case, self.user1, CaseAction.OPEN, assignee=self.moh)
 
         # backend has a message in the case time window that we don't have locally
-        remote_message1 = {
-            'id': 102,
-            'contact': {'id': self.ann.pk, 'name': "Ann"},
-            'urn': None,
-            'text': "Non casepro message...",
-            'time': d2,
-            'direction': 'O',
-            'case': None,
-            'sender': None,
-        }
+        remote_message1 = Outgoing(backend_broadcast_id=102, contact=self.ann, text="Non casepro message...",
+                                   created_on=d2)
         mock_fetch_contact_messages.return_value = [remote_message1]
 
         timeline_url = reverse('cases.case_timeline', args=[case.pk])
@@ -676,14 +668,12 @@ class CaseCRUDLTest(BaseCasesTest):
         t0 = microseconds_to_datetime(response.json['max_time'])
 
         self.assertEqual(len(response.json['results']), 3)
-        self.assertEqual(response.json['results'][0]['type'], 'M')
+        self.assertEqual(response.json['results'][0]['type'], 'I')
         self.assertEqual(response.json['results'][0]['item']['text'], "What is AIDS?")
         self.assertEqual(response.json['results'][0]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
-        self.assertEqual(response.json['results'][0]['item']['direction'], 'I')
-        self.assertEqual(response.json['results'][1]['type'], 'M')
+        self.assertEqual(response.json['results'][1]['type'], 'O')
         self.assertEqual(response.json['results'][1]['item']['text'], "Non casepro message...")
         self.assertEqual(response.json['results'][1]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
-        self.assertEqual(response.json['results'][1]['item']['direction'], 'O')
         self.assertEqual(response.json['results'][2]['type'], 'A')
         self.assertEqual(response.json['results'][2]['item']['action'], 'O')
 
@@ -724,9 +714,8 @@ class CaseCRUDLTest(BaseCasesTest):
         t3 = microseconds_to_datetime(response.json['max_time'])
 
         self.assertEqual(len(response.json['results']), 1)
-        self.assertEqual(response.json['results'][0]['type'], 'M')
+        self.assertEqual(response.json['results'][0]['type'], 'O')
         self.assertEqual(response.json['results'][0]['item']['text'], "It's bad")
-        self.assertEqual(response.json['results'][0]['item']['direction'], 'O')
 
         # contact sends a reply
         d4 = timezone.now()
@@ -738,9 +727,8 @@ class CaseCRUDLTest(BaseCasesTest):
         t4 = microseconds_to_datetime(response.json['max_time'])
 
         self.assertEqual(len(response.json['results']), 1)
-        self.assertEqual(response.json['results'][0]['type'], 'M')
+        self.assertEqual(response.json['results'][0]['type'], 'I')
         self.assertEqual(response.json['results'][0]['item']['text'], "OK thanks")
-        self.assertEqual(response.json['results'][0]['item']['direction'], 'I')
 
         # page again looks for new timeline activity
         response = self.url_get('unicef', '%s?after=%s' % (timeline_url, datetime_to_microseconds(t4)))
@@ -774,16 +762,7 @@ class CaseCRUDLTest(BaseCasesTest):
 
         # backend has the message sent during the case as well as the unrelated message
         mock_fetch_contact_messages.return_value = [
-            {
-                'id': 202,
-                'contact': {'id': self.ann.pk, 'name': "Ann"},
-                'urn': None,
-                'text': "It's bad",
-                'time': d3,
-                'direction': 'O',
-                'case': None,
-                'sender': None,
-            },
+            Outgoing(backend_broadcast_id=202, contact=self.ann, text="It's bad", created_on=d3),
             remote_message1
         ]
 
@@ -792,24 +771,21 @@ class CaseCRUDLTest(BaseCasesTest):
         items = response.json['results']
 
         self.assertEqual(len(items), 7)
-        self.assertEqual(items[0]['type'], 'M')
+        self.assertEqual(items[0]['type'], 'I')
         self.assertEqual(items[0]['item']['text'], "What is AIDS?")
         self.assertEqual(items[0]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
-        self.assertEqual(items[0]['item']['direction'], 'I')
-        self.assertEqual(items[1]['type'], 'M')
+        self.assertEqual(items[1]['type'], 'O')
         self.assertEqual(items[1]['item']['text'], "Non casepro message...")
         self.assertEqual(items[1]['item']['contact'], {'id': self.ann.pk, 'name': "Ann"})
-        self.assertEqual(items[1]['item']['direction'], 'O')
         self.assertEqual(items[1]['item']['sender'], None)
         self.assertEqual(items[2]['type'], 'A')
         self.assertEqual(items[2]['item']['action'], 'O')
         self.assertEqual(items[3]['type'], 'A')
         self.assertEqual(items[3]['item']['action'], 'N')
-        self.assertEqual(items[4]['type'], 'M')
-        self.assertEqual(items[4]['item']['direction'], 'O')
+        self.assertEqual(items[4]['type'], 'O')
         self.assertEqual(items[4]['item']['sender'], {'id': self.user1.pk, 'name': "Evan"})
-        self.assertEqual(items[5]['type'], 'M')
-        self.assertEqual(items[5]['item']['direction'], 'I')
+        self.assertEqual(items[5]['type'], 'I')
+        self.assertEqual(items[5]['item']['text'], "OK thanks")
         self.assertEqual(items[6]['type'], 'A')
         self.assertEqual(items[6]['item']['action'], 'C')
 

--- a/casepro/msgs/tests.py
+++ b/casepro/msgs/tests.py
@@ -689,7 +689,6 @@ class MessageTest(BaseCasesTest):
             'labels': [{'id': self.aids.pk, 'name': "AIDS"}],
             'flagged': False,
             'archived': False,
-            'direction': 'I',
             'flow': False,
             'case': None
         })
@@ -1114,7 +1113,6 @@ class OutgoingTest(BaseCasesTest):
             'urn': None,
             'text': "That's great",
             'time': outgoing.created_on,
-            'direction': 'O',
             'case': None,
             'sender': {'id': self.user1.pk, 'name': "Evan"}
         })
@@ -1149,7 +1147,6 @@ class OutgoingCRUDLTest(BaseCasesTest):
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urn': None,
                 'text': "Hello 2",
-                'direction': 'O',
                 'case': None,
                 'sender': {'id': self.user1.pk, 'name': "Evan"},
                 'time': format_iso8601(out2.created_on)
@@ -1159,7 +1156,6 @@ class OutgoingCRUDLTest(BaseCasesTest):
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urn': None,
                 'text': "Hello 1",
-                'direction': 'O',
                 'case': None,
                 'sender': {'id': self.admin.pk, 'name': "Kidus"},
                 'time': format_iso8601(out1.created_on)
@@ -1176,7 +1172,6 @@ class OutgoingCRUDLTest(BaseCasesTest):
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urn': None,
                 'text': "Hello 2",
-                'direction': 'O',
                 'case': None,
                 'sender': {'id': self.user1.pk, 'name': "Evan"},
                 'time': format_iso8601(out2.created_on)
@@ -1212,7 +1207,6 @@ class OutgoingCRUDLTest(BaseCasesTest):
                 'contact': {'id': self.bob.pk, 'name': "Bob"},
                 'urn': None,
                 'text': "Hello 2",
-                'direction': 'O',
                 'case': None,
                 'sender': {'id': self.admin.pk, 'name': "Kidus"},
                 'time': format_iso8601(out2.created_on),
@@ -1228,7 +1222,6 @@ class OutgoingCRUDLTest(BaseCasesTest):
                 'contact': {'id': self.ann.pk, 'name': "Ann"},
                 'urn': None,
                 'text': "Hello 1",
-                'direction': 'O',
                 'case': {'id': case.pk, 'assignee': {'id': self.moh.pk, 'name': "MOH"}},
                 'sender': {'id': self.user1.pk, 'name': "Evan"},
                 'time': format_iso8601(out1.created_on),

--- a/casepro/utils/__init__.py
+++ b/casepro/utils/__init__.py
@@ -138,3 +138,17 @@ def date_range(start, stop):
     """
     for n in range(int((stop - start).days)):
         yield start + timedelta(n)
+
+
+class TimelineItem(object):
+    """
+    Wraps a message or action for easier inclusion in a merged timeline
+    """
+    def __init__(self, item):
+        self.item = item
+
+    def get_time(self):
+        return self.item.created_on
+
+    def to_json(self):
+        return {'time': self.get_time(), 'type': self.item.TIMELINE_TYPE, 'item': self.item.as_json()}

--- a/casepro/utils/tests.py
+++ b/casepro/utils/tests.py
@@ -106,7 +106,6 @@ class UtilsTest(BaseCasesTest):
         ])
         self.assertEqual(list(date_range(date(2015, 1, 29), date(2015, 1, 29))), [])
 
-
     def test_timeline_item(self):
         d1 = datetime(2015, 10, 1, 9, 0, 0, 0, pytz.UTC)
         ann = self.create_contact(self.unicef, 'C-101', "Ann")

--- a/casepro/utils/tests.py
+++ b/casepro/utils/tests.py
@@ -11,7 +11,7 @@ from enum import Enum
 
 from casepro.test import BaseCasesTest
 
-from . import safe_max, normalize, match_keywords, truncate, str_to_bool, json_encode
+from . import safe_max, normalize, match_keywords, truncate, str_to_bool, json_encode, TimelineItem
 from . import date_to_milliseconds, datetime_to_microseconds, microseconds_to_datetime, month_range, date_range
 from .email import send_email
 from .middleware import JSONMiddleware
@@ -102,6 +102,12 @@ class UtilsTest(BaseCasesTest):
             date(2015, 2, 1)
         ])
         self.assertEqual(list(date_range(date(2015, 1, 29), date(2015, 1, 29))), [])
+
+    def test_timeline_item(self):
+        d1 = datetime(2015, 10, 1, 9, 0, 0, 0, pytz.UTC)
+        ann = self.create_contact(self.unicef, 'C-101', "Ann")
+        msg = self.create_message(self.unicef, 102, ann, "Hello", created_on=d1)
+        self.assertEqual(TimelineItem(msg).to_json(), {'time': d1, 'type': 'I', 'item': msg.as_json()})
 
 
 class EmailTest(BaseCasesTest):

--- a/karma/test-services.coffee
+++ b/karma/test-services.coffee
@@ -73,15 +73,12 @@ describe('services:', () ->
 
     describe('fetchTimeline', () ->
       it('gets cases from timeline endpoint', () ->
-        $httpBackend.expectGET('/case/timeline/501/?after=2016-05-28T09:00:00.000Z').respond('{"results":[{"id":501,"time":"2016-05-17T08:49:13.698864","type":"A"}]}')
+        $httpBackend.expectGET('/case/timeline/501/?after=2016-05-28T09:00:00.000Z').respond('{"results":[{"time":"2016-05-17T08:49:13.698864","type":"A","item":{}}]}')
         CaseService.fetchTimeline(test.case1, utcdate(2016, 5, 28, 9, 0, 0, 0)).then((data) ->
           expect(data.results).toEqual([{
-            id: 501,
             time: utcdate(2016, 5, 17, 8, 49, 13, 698),
             type: 'A',
-            is_action: true,
-            is_message_in: false,
-            is_message_out: false
+            item: {}
           }])
         )
         $httpBackend.flush()

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -335,12 +335,7 @@ services.factory('CaseService', ['$http', '$httpParamSerializer', '$window', ($h
       params = {after: after}
 
       return $http.get('/case/timeline/' + caseObj.id + '/?' + $httpParamSerializer(params)).then((response) ->
-        for event in response.data.results
-          # parse datetime string
-          event.time = utils.parseIso8601(event.time)
-          event.is_action = event.type == 'A'
-          event.is_message_in = event.type == 'M' and event.item.direction == 'I'
-          event.is_message_out = event.type == 'M' and event.item.direction == 'O'
+        utils.parseDates(response.data.results, 'time')
 
         return {results: response.data.results, maxTime: response.data.max_time}
       )

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -76,11 +76,11 @@
               [[ msgCharsRemaining ]]
 
         .timeline{ ng-controller:"CaseTimelineController", ng-init:"init()" }
-          .timeline-event.clearfix{ ng-repeat:"event in timeline | reverse", ng-class:'{ "timeline-action": event.is_action, "timeline-incoming": event.is_message_in, "timeline-outgoing": event.is_message_out }' }
+          .timeline-event.clearfix{ ng-repeat:"event in timeline | reverse", ng-class:'{ "timeline-action": (event.type == "A"), "timeline-incoming": (event.type == "I"), "timeline-outgoing": (event.type == "O") }' }
             .event-time
               [[ event.time | autodate ]]
 
-            .{ ng-if:"event.is_action" }
+            .{ ng-if:'event.type == "A"' }
               %a{ ng-href:"/user/read/[[ event.item.created_by.id ]]/" }
                 [[ event.item.created_by.name ]]
 
@@ -119,10 +119,10 @@
               .action-note{ ng-if:"event.item.note" }
                 [[ event.item.note ]]
 
-            .{ ng-if:"event.is_message_in" }
+            .{ ng-if:'event.type == "I"' }
               [[ event.item.text ]]
 
-            .{ ng-if:"event.is_message_out" }
+            .{ ng-if:'event.type == "O"' }
               %span{ ng-if:"event.item.sender" }
                 %a{ ng-href:"/user/read/[[ event.item.sender.id ]]/" }><
                   [[ event.item.sender.name ]]


### PR DESCRIPTION
* `backend.fetch_contact_messages(...)` now returns transient model instances rather than translating backend JSON into CasePro JSON. This allows JSON rendering of case timelines to be handled in view layer like everything else.
* `TimelineItem` utility class simplifies JSON rendering of timeline items

We'll likely be adding a timeline of messages to the contact page and these changes will aid with that.