### PR TITLE
Change password hasher to cheaper one for test run speedup

### DIFF
--- a/casepro/settings.py.dev
+++ b/casepro/settings.py.dev
@@ -26,3 +26,8 @@ DATABASES = {
         }
     }
 }
+
+# Speed improvement for test runs.
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+)


### PR DESCRIPTION
There is a small change that we can make to the dev/testing settings file to improve test run time, from 379.215s to 278.501s on my local machine.