### PR TITLE
Set the password hasher to MD5 for tests only and not in settings.py.dev

### DIFF
--- a/casepro/settings.py.dev
+++ b/casepro/settings.py.dev
@@ -26,8 +26,3 @@ DATABASES = {
         }
     }
 }
-
-# Speed improvement for test runs.
-PASSWORD_HASHERS = (
-    'django.contrib.auth.hashers.MD5PasswordHasher',
-)

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -12,11 +12,13 @@ from django.utils.translation import ugettext_lazy as _
 # -----------------------------------------------------------------------------------
 TESTING = sys.argv[1:2] == ['test']
 
-# Django settings for tns_glass project.
-THUMBNAIL_DEBUG = False
-
-DEBUG = True
-TEMPLATE_DEBUG = DEBUG
+if TESTING:
+    PASSWORD_HASHERS = ('django.contrib.auth.hashers.MD5PasswordHasher',)
+    DEBUG = False
+    TEMPLATE_DEBUG = False
+else:
+    DEBUG = True
+    TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     ('Nyaruka', 'code@nyaruka.com'),


### PR DESCRIPTION
@rudigiesler no sooner had I merged that last PR did I realise this changes it for my local dev instance even when not testing. Does change below work for you?