### PR TITLE
Tabbed pages fix

### DIFF
--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -590,12 +590,14 @@ describe('controllers:', () ->
     PartnerService = null
     StatisticsService = null
     UserService = null
+    $location = null
     $scope = null
 
-    beforeEach(inject((_PartnerService_, _StatisticsService_, _UserService_) ->
+    beforeEach(inject((_PartnerService_, _StatisticsService_, _UserService_, _$location_) ->
       PartnerService = _PartnerService_
       StatisticsService = _StatisticsService_
       UserService = _UserService_
+      $location = _$location_
 
       $scope = $rootScope.$new()
       $window.contextData = {partner: test.moh}
@@ -613,6 +615,7 @@ describe('controllers:', () ->
 
       expect(StatisticsService.repliesChart).toHaveBeenCalledWith(test.moh, null)
       expect($scope.initialisedTabs).toEqual([0])
+      expect($location.path()).toEqual('/summary')
 
       $scope.onTabSelect(2)
 
@@ -621,6 +624,7 @@ describe('controllers:', () ->
 
       expect($scope.users).toEqual(users)
       expect($scope.initialisedTabs).toEqual([0, 2])
+      expect($location.path()).toEqual('/users')
 
       # select the users tab again
       $scope.onTabSelect(2)
@@ -628,6 +632,7 @@ describe('controllers:', () ->
       # users shouldn't be re-fetched
       expect(UserService.fetchInPartner.calls.count()).toEqual(1)
       expect($scope.initialisedTabs).toEqual([0, 2])
+      expect($location.path()).toEqual('/users')
     )
 
     it('onDeletePartner', () ->

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -75,12 +75,13 @@ controllers.controller('InboxController', ['$scope', '$window', '$location', 'La
 controllers.controller('BaseTabsController', ['$scope', '$location', ($scope, $location) ->
   $scope.initialisedTabs = []
 
-  path = $location.path()
-  if path
-    initialTabSlug = path.substring(1)  # ignore initial /
-    $scope.active = $scope.tabSlugs.indexOf(initialTabSlug)
-  else
-    $scope.active = 0
+  $scope.activateTabFromPath = () ->
+    path = $location.path()
+    if path
+      initialTabSlug = path.substring(1)  # ignore initial /
+      $scope.active = $scope.tabSlugs.indexOf(initialTabSlug)
+    else
+      $scope.active = 0
 
   $scope.onTabSelect = (tab) ->
     slug = $scope.tabSlugs[tab]
@@ -90,6 +91,9 @@ controllers.controller('BaseTabsController', ['$scope', '$location', ($scope, $l
     if tab not in $scope.initialisedTabs
       $scope.onTabInit(slug)
       $scope.initialisedTabs.push(tab)
+
+  $scope.activateTabFromPath()
+  $scope.$on('$locationChangeSuccess', () -> $scope.activateTabFromPath())
 ])
 
 


### PR DESCRIPTION
https://github.com/rapidpro/casepro/pull/85 fixed tabs so that tab changes are reflected in the URL, and that when a page is reloaded, the initial tab is activated based on the URL.

But it doesn't update the active tab if the location changes but the page isn't reloaded (e.g. changing tabs, and then pressing the browser back button). This PR fixes that.