### PR TITLE
Render contact fields using labels

### DIFF
--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from dash.orgs.models import Org, TaskState
 from dash.orgs.views import OrgPermsMixin, OrgObjPermsMixin
 from datetime import timedelta
+from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse, JsonResponse
 from django.utils.timezone import now
@@ -70,6 +71,7 @@ class CaseCRUDL(SmartCRUDL):
                 'fields': [f.as_json() for f in fields]
             })
 
+            context['anon_contacts'] = getattr(settings, 'SITE_ANON_CONTACTS', False)
             context['max_msg_chars'] = MAX_MESSAGE_CHARS
             context['can_update'] = can_update
             context['alert'] = self.request.GET.get('alert', None)

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -117,6 +117,12 @@ class Field(models.Model):
     def __str__(self):
         return self.key
 
+    def as_json(self):
+        """
+        Prepares a contact for JSON serialization
+        """
+        return {'key': self.key, 'label': self.label, 'value_type': self.value_type}
+
     class Meta:
         unique_together = ('org', 'key')
 

--- a/karma/test-directives.coffee
+++ b/karma/test-directives.coffee
@@ -58,4 +58,45 @@ describe('directives:', () ->
       expect(element.isolateScope().popoverIsOpen).toEqual(false)
     )
   )
+
+  describe('fieldvalue', () ->
+    $filter = null
+
+    beforeEach(() ->
+      inject(( _$filter_) ->
+        $filter = _$filter_
+      )
+    )
+
+    it('it looksup and formats value based on type', () ->
+      $scope = $rootScope.$new()
+      $scope.ann = {id: 401, name: "Ann", fields: {nid: 1234567, edd: '2016-07-04T12:59:46.309033Z'}}
+      $scope.myfields = [
+        {key: 'nid', label: "NID", value_type:'N'},
+        {key: 'edd', label: "EDD", value_type:'D'},
+        {key: 'nickname', label: "Nickname", value_type:'T'}
+      ]
+
+      # check numerical field
+      element = $compile('<cp-fieldvalue contact="ann" field="myfields[0]" />')($scope)
+      $rootScope.$digest()
+
+      expect(element.isolateScope().contact).toEqual($scope.ann)
+      expect(element.isolateScope().field).toEqual($scope.myfields[0])
+      expect(element.isolateScope().value).toEqual("1,234,567")
+      expect(element.text()).toEqual("1,234,567")
+
+      # check date field
+      element = $compile('<cp-fieldvalue contact="ann" field="myfields[1]" />')($scope)
+      $rootScope.$digest()
+
+      expect(element.text()).toEqual("Jul 4, 2016")
+
+      # check field with no value
+      element = $compile('<cp-fieldvalue contact="ann" field="myfields[2]" />')($scope)
+      $rootScope.$digest()
+
+      expect(element.text()).toEqual("")
+    )
+  )
 )

--- a/karma/test-directives.coffee
+++ b/karma/test-directives.coffee
@@ -30,14 +30,17 @@ describe('directives:', () ->
       $templateCache.put('/partials/directive_contact.html', '[[ contact.name ]]')
       $scope = $rootScope.$new()
       $scope.ann = {id: 401, name: "Ann"}
+      $scope.myfields = [{key: 'age', label: "Age"}]
 
       fetch = spyOnPromise($q, $scope, ContactService, 'fetch')
 
-      element = $compile('<cp-contact contact="ann" />')($scope)
+      element = $compile('<cp-contact contact="ann" fields="myfields" />')($scope)
       $rootScope.$digest()
 
       expect(element.html()).toContain("Ann");
 
+      expect(element.isolateScope().contact).toEqual($scope.ann)
+      expect(element.isolateScope().fields).toEqual([{key: 'age', label: "Age"}])
       expect(element.isolateScope().fetched).toEqual(false)
       expect(element.isolateScope().popoverIsOpen).toEqual(false)
       expect(element.isolateScope().popoverTemplateUrl).toEqual('/partials/popover_contact.html')

--- a/karma/test-directives.coffee
+++ b/karma/test-directives.coffee
@@ -96,7 +96,7 @@ describe('directives:', () ->
       element = $compile('<cp-fieldvalue contact="ann" field="myfields[2]" />')($scope)
       $rootScope.$digest()
 
-      expect(element.text()).toEqual("")
+      expect(element.text()).toEqual("--")
     )
   )
 )

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -25,6 +25,7 @@ controllers.controller('InboxController', ['$scope', '$window', '$location', 'La
   $scope.user = $window.contextData.user
   $scope.labels = $window.contextData.labels
   $scope.groups = $window.contextData.groups
+  $scope.fields = $window.contextData.fields
 
   $scope.activeLabel = null
   $scope.activeContact = null
@@ -505,6 +506,7 @@ controllers.controller('HomeController', ['$scope', '$controller', 'LabelService
 controllers.controller('CaseController', ['$scope', '$window', '$timeout', 'CaseService', 'ContactService', 'MessageService', 'PartnerService', 'UtilsService', ($scope, $window, $timeout, CaseService, ContactService, MessageService, PartnerService, UtilsService) ->
 
   $scope.allLabels = $window.contextData.all_labels
+  $scope.fields = $window.contextData.fields
   
   $scope.caseObj = null
   $scope.contact = null
@@ -685,6 +687,7 @@ controllers.controller('PartnerController', ['$scope', '$window', '$controller',
   $controller('BaseTabsController', {$scope: $scope})
 
   $scope.partner = $window.contextData.partner
+  $scope.fields = $window.contextData.fields
   $scope.users = []
 
   $scope.onTabInit = (tab) ->

--- a/static/coffee/directives.coffee
+++ b/static/coffee/directives.coffee
@@ -28,3 +28,24 @@ directives.directive('cpContact', () ->
     ]      
   }
 )
+
+#----------------------------------------------------------------------------
+# A contact field value
+#----------------------------------------------------------------------------
+directives.directive('cpFieldvalue', () ->
+  return {
+    restrict: 'E',
+    scope: {contact: '=', field: '='},
+    template: '[[ value ]]',
+    controller: ['$scope', '$filter', ($scope, $filter) ->
+      raw = $scope.contact.fields[$scope.field.key]
+
+      if $scope.field.value_type == 'N'
+        $scope.value = $filter('number')(raw)
+      else if $scope.field.value_type == 'D'
+        $scope.value = $filter('date')(raw, 'mediumDate')
+      else
+        $scope.value = raw
+    ]
+  }
+)

--- a/static/coffee/directives.coffee
+++ b/static/coffee/directives.coffee
@@ -2,14 +2,12 @@ directives = angular.module('cases.directives', []);
 
 
 #----------------------------------------------------------------------------
-#
+# A contact reference which displays a popover when hovered over
 #----------------------------------------------------------------------------
 directives.directive('cpContact', () ->
   return {
     restrict: 'E',
-    scope: {
-      contact: '=contact'
-    },
+    scope: {contact: '=', fields: '='},
     templateUrl: '/partials/directive_contact.html',
     controller: ['$scope', 'ContactService', ($scope, ContactService) ->
       $scope.fetched = false
@@ -28,5 +26,16 @@ directives.directive('cpContact', () ->
       $scope.closePopover = () ->
         $scope.popoverIsOpen = false
     ]      
+  }
+)
+
+#----------------------------------------------------------------------------
+# A list of contact field label/value pairs
+#----------------------------------------------------------------------------
+directives.directive('cpContactdetails', () ->
+  return {
+    restrict: 'E',
+    scope: {contact: '=', fields: '='},
+    templateUrl: '/partials/directive_contact_details.html',
   }
 )

--- a/static/coffee/directives.coffee
+++ b/static/coffee/directives.coffee
@@ -28,14 +28,3 @@ directives.directive('cpContact', () ->
     ]      
   }
 )
-
-#----------------------------------------------------------------------------
-# A list of contact field label/value pairs
-#----------------------------------------------------------------------------
-directives.directive('cpContactdetails', () ->
-  return {
-    restrict: 'E',
-    scope: {contact: '=', fields: '='},
-    templateUrl: '/partials/directive_contact_details.html',
-  }
-)

--- a/static/coffee/directives.coffee
+++ b/static/coffee/directives.coffee
@@ -40,12 +40,15 @@ directives.directive('cpFieldvalue', () ->
     controller: ['$scope', '$filter', ($scope, $filter) ->
       raw = $scope.contact.fields[$scope.field.key]
 
-      if $scope.field.value_type == 'N'
-        $scope.value = $filter('number')(raw)
-      else if $scope.field.value_type == 'D'
-        $scope.value = $filter('date')(raw, 'mediumDate')
+      if raw
+        if $scope.field.value_type == 'N'
+          $scope.value = $filter('number')(raw)
+        else if $scope.field.value_type == 'D'
+          $scope.value = $filter('date')(raw, 'mediumDate')
+        else
+          $scope.value = raw
       else
-        $scope.value = raw
+        $scope.value = '--'
     ]
   }
 )

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -142,21 +142,22 @@
         .panel.panel-default{ ng-if:"contact" }
           .panel-heading
             - trans "Contact"
-            .pull-away
-              %a.btn.btn-default.btn-xs{ ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
-                - trans "View"
-          .list-group
+          .panel-body
             .container-fluid
-              .list-group-item.row
-                .col-sm-6
+              .row
+                .contact-field-label.col-sm-6
                   - trans "Name"
-                .col-sm-6
+                .contact-field-value.col-sm-6
                   [[ caseObj.contact.name ]]
-              .list-group-item.row{ ng-repeat:"field in fields" }
-                .col-sm-6
+              .row{ ng-repeat:"field in fields" }
+                .contact-field-label.col-sm-6
                   [[ field.label ]]
-                .col-sm-6
+                .contact-field-value.col-sm-6
                   [[ contact.fields[field.key] ]]
+          .list-group
+            %a.list-group-item.centered{ ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
+              %span.text-primary
+                - trans "View"
 
 
 - block extra-style
@@ -221,4 +222,7 @@
     .timeline-event .action-note {
       padding: 0.5em 0 0 2em;
       font-style: italic;
+    }
+    .contact-field-label {
+      font-weight: bold;
     }

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -142,9 +142,14 @@
         .panel.panel-default{ ng-if:"contact" }
           .panel-heading
             - trans "Contact"
-            %a{ ng-href:"/contact/read/[[ contact.id ]]/" }
-              [[ caseObj.contact.name ]]
+            .pull-away
+              %a{ ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
+                - trans "View"
           .panel-body
+            %strong><
+              - trans "Name"
+            :
+            [[ caseObj.contact.name ]]
             <cp-contactdetails contact="contact" fields="fields" />
 
 

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -153,7 +153,7 @@
                 .contact-field-label.col-sm-6
                   [[ field.label ]]
                 .contact-field-value.col-sm-6
-                  [[ contact.fields[field.key] ]]
+                  <cp-fieldvalue contact="contact" field="field" />
           .list-group
             %a.list-group-item.centered{ ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
               %span.text-primary

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -143,14 +143,20 @@
           .panel-heading
             - trans "Contact"
             .pull-away
-              %a{ ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
+              %a.btn.btn-default.btn-xs{ ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
                 - trans "View"
-          .panel-body
-            %strong><
-              - trans "Name"
-            :
-            [[ caseObj.contact.name ]]
-            <cp-contactdetails contact="contact" fields="fields" />
+          .list-group
+            .container-fluid
+              .list-group-item.row
+                .col-sm-6
+                  - trans "Name"
+                .col-sm-6
+                  [[ caseObj.contact.name ]]
+              .list-group-item.row{ ng-repeat:"field in fields" }
+                .col-sm-6
+                  [[ field.label ]]
+                .col-sm-6
+                  [[ contact.fields[field.key] ]]
 
 
 - block extra-style

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -145,11 +145,7 @@
             %a{ ng-href:"/contact/read/[[ contact.id ]]/" }
               [[ caseObj.contact.name ]]
           .panel-body
-            .contact-details
-              .contact-field{ ng-repeat:"(key, val) in contact.fields" }
-                %strong><
-                  [[ key ]]
-                : [[ val ]]
+            <cp-contactdetails contact="contact" fields="fields" />
 
 
 - block extra-style

--- a/templates/cases/inbox_messages.haml
+++ b/templates/cases/inbox_messages.haml
@@ -140,7 +140,7 @@
           [[ item.time | autodate ]]
         .message-contact
           %a{ ng-click:"activateContact(item.contact)" }><
-            <cp-contact contact="item.contact">
+            <cp-contact contact="item.contact" fields="fields">
         .message-text
           %span.label-container{ ng-if:"item.flow" }
             %span.label.label-info

--- a/templates/cases/inbox_outgoing.haml
+++ b/templates/cases/inbox_outgoing.haml
@@ -40,7 +40,7 @@
           to
           %span{ ng-if:"item.contact" }
             %a{ ng-click:"activateContact(item.contact)", style:"white-space: nowrap;" }><
-              <cp-contact contact="item.contact">
+              <cp-contact contact="item.contact" fields="fields">
           %span{ ng-if:"item.urns.length" }
             <ng-pluralize count="item.urns.length" when="{'one': '1 recipient', 'other': '{} recipients'}">
             </ng-pluralize>

--- a/templates/cases/partner_read.haml
+++ b/templates/cases/partner_read.haml
@@ -134,7 +134,7 @@
                       %span.glyphicon.glyphicon-flag{ ng-if:"item.reply_to.flagged" }
                     %td{ nowrap:"" }
                       %a{ ng-href:"/contact/read/[[ item.contact.id ]]" }><
-                        <cp-contact contact="item.contact">
+                        <cp-contact contact="item.contact" fields="fields">
 
             .loading{ ng-if:"oldItemsLoading" }
             .none{ ng-hide:"oldItemsLoading || items.length > 0" }

--- a/templates/partials/directive_contact_details.haml
+++ b/templates/partials/directive_contact_details.haml
@@ -1,0 +1,6 @@
+.contact-details
+  .contact-field{ ng-repeat:"field in fields" }
+    %strong><
+      [[ field.label ]]
+    :
+    [[ contact.fields[field.key] ]]

--- a/templates/partials/directive_contact_details.haml
+++ b/templates/partials/directive_contact_details.haml
@@ -1,6 +1,0 @@
-.contact-details
-  .contact-field{ ng-repeat:"field in fields" }
-    %strong><
-      [[ field.label ]]
-    :
-    [[ contact.fields[field.key] ]]

--- a/templates/partials/popover_contact.haml
+++ b/templates/partials/popover_contact.haml
@@ -1,8 +1,4 @@
-.
+.contact-popover
   .loading{ ng-if:"!fetched" }
   .{ ng-if:"fetched" }
-    .{ ng-repeat:"(key, value) in contact.fields" }
-      %strong><
-        [[ key ]]
-      :
-      [[ value ]]
+    <cp-contactdetails contact="contact" fields="fields" />

--- a/templates/partials/popover_contact.haml
+++ b/templates/partials/popover_contact.haml
@@ -5,4 +5,4 @@
       %strong><
         [[ field.label ]]
       :
-      [[ contact.fields[field.key] ]]
+      <cp-fieldvalue contact="contact" field="field" />

--- a/templates/partials/popover_contact.haml
+++ b/templates/partials/popover_contact.haml
@@ -1,4 +1,8 @@
 .contact-popover
   .loading{ ng-if:"!fetched" }
   .{ ng-if:"fetched" }
-    <cp-contactdetails contact="contact" fields="fields" />
+    .contact-field{ ng-repeat:"field in fields" }
+      %strong><
+        [[ field.label ]]
+      :
+      [[ contact.fields[field.key] ]]


### PR DESCRIPTION
Also updates the styling of the contact details panel on the case page, to use same styling as that which will be used for pods provided by case plugins.

And ensures that date and numerical field values are formatted accordingly. So

<img width="341" alt="screen shot 2016-07-21 at 14 57 05" src="https://cloud.githubusercontent.com/assets/675558/17023394/735d63b4-4f53-11e6-91c2-a31ff5de6c18.png">

becomes:

<img width="339" alt="screen shot 2016-07-21 at 15 05 08" src="https://cloud.githubusercontent.com/assets/675558/17023634/92dc7198-4f54-11e6-8335-cb04f85019e7.png">

