### PR TITLE
Translate language ISO codes into names when displaying

### DIFF
--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from django_redis import get_redis_connection
 
 from casepro.backend import get_backend
+from casepro.utils import get_language_name
 
 FIELD_LOCK_KEY = 'lock:field:%d:%s'
 GROUP_LOCK_KEY = 'lock:group:%d:%s'
@@ -268,6 +269,11 @@ class Contact(models.Model):
 
         if full:
             result['fields'] = self.get_fields(visible=True)
+
+            if self.language:
+                result['language'] = {'code': self.language, 'name': get_language_name(self.language)}
+            else:
+                result['language'] = None
 
         return result
 

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -201,6 +201,12 @@ class Contact(models.Model):
         else:
             return fields
 
+    def get_language(self):
+        if self.language:
+            return {'code': self.language, 'name': get_language_name(self.language)}
+        else:
+            return None
+
     def prepare_for_case(self):
         """
         Prepares this contact to be put in a case
@@ -269,11 +275,7 @@ class Contact(models.Model):
 
         if full:
             result['fields'] = self.get_fields(visible=True)
-
-            if self.language:
-                result['language'] = {'code': self.language, 'name': get_language_name(self.language)}
-            else:
-                result['language'] = None
+            result['language'] = self.get_language()
 
         return result
 

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -91,10 +91,13 @@ class ContactTest(BaseCasesTest):
     def test_as_json(self):
         self.assertEqual(self.ann.as_json(full=False), {'id': self.ann.pk, 'name': "Ann"})
 
-        # full=True means include visible contact fields
-        self.assertEqual(self.ann.as_json(full=True), {'id': self.ann.pk,
-                                                       'name': "Ann",
-                                                       'fields': {'nickname': None, 'age': "32"}})
+        # full=True means include visible contact fields and laanguage etc
+        self.assertEqual(self.ann.as_json(full=True), {
+            'id': self.ann.pk,
+            'name': "Ann",
+            'fields': {'nickname': None, 'age': "32"},
+            'language': {'code': 'eng', 'name': "English"}
+        })
 
         # if site uses anon contacts then name is obscured
         with override_settings(SITE_ANON_CONTACTS=True):
@@ -155,7 +158,12 @@ class ContactCRUDLTest(BaseCasesTest):
 
         response = self.url_get('unicef', url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json, {'id': self.ann.pk, 'name': "Ann", 'fields': {'age': '32', 'nickname': None}})
+        self.assertEqual(response.json, {
+            'id': self.ann.pk,
+            'name': "Ann",
+            'fields': {'age': '32', 'nickname': None},
+            'language': {'code': 'eng', 'name': "English"}
+        })
 
 
 class FieldCRUDLTest(BaseCasesTest):

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -99,6 +99,16 @@ class ContactTest(BaseCasesTest):
             'language': {'code': 'eng', 'name': "English"}
         })
 
+        self.ann.language = None
+        self.ann.save()
+
+        self.assertEqual(self.ann.as_json(full=True), {
+            'id': self.ann.pk,
+            'name': "Ann",
+            'fields': {'nickname': None, 'age': "32"},
+            'language': None
+        })
+
         # if site uses anon contacts then name is obscured
         with override_settings(SITE_ANON_CONTACTS=True):
             self.assertEqual(self.ann.as_json(full=False), {'id': self.ann.pk, 'name': "7B7DD8"})

--- a/casepro/contacts/views.py
+++ b/casepro/contacts/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseRedirect, JsonResponse
 from django.utils.translation import ugettext_lazy as _
 from smartmin.views import SmartCRUDL, SmartReadView, SmartListView, SmartFormView
 
-from casepro.utils import JSONEncoder
+from casepro.utils import JSONEncoder, get_language_name
 
 from .models import Contact, Group, Field
 
@@ -43,6 +43,9 @@ class ContactCRUDL(SmartCRUDL):
                 fields += self.superuser_fields
 
             return fields
+
+        def get_language(self, obj):
+            return get_language_name(obj.language) if obj.language else None
 
         def get_groups(self, obj):
             return ", ".join([g.name for g in obj.groups.all()])

--- a/casepro/utils/__init__.py
+++ b/casepro/utils/__init__.py
@@ -172,10 +172,7 @@ def uuid_to_int(uuid):
 
 def get_language_name(iso_code):
     """
-    Gets a language name for a given ISO639-2 code.
-
-    Args:
-        iso_code: three character iso_code
+    Gets the language name for the given ISO639-2 code.
     """
     if iso_code not in LANGUAGES_BY_CODE:
         try:

--- a/casepro/utils/tests.py
+++ b/casepro/utils/tests.py
@@ -129,12 +129,14 @@ class UtilsTest(BaseCasesTest):
         self.assertTrue(uuid_to_int(uuid.hex) >= 0)
 
     def test_get_language_name(self):
-        self.assertEquals('French', get_language_name('fre'))
-        self.assertEquals('French', get_language_name('fre'))  # from cache
-        self.assertEquals('Creoles and pidgins, English based', get_language_name('cpe'))
+        self.assertEqual(get_language_name('fre'), "French")
+        self.assertEqual(get_language_name('fre'), "French")  # from cache
+        self.assertEqual(get_language_name('cpe'), "Creoles and pidgins, English based")
 
         # should strip off anything after an open paren or semicolon
-        self.assertEquals('Official Aramaic', get_language_name('arc'))
+        self.assertEqual(get_language_name('arc'), "Official Aramaic")
+
+        self.assertIsNone(get_language_name('xxxxx'))
 
 
 class EmailTest(BaseCasesTest):

--- a/casepro/utils/tests.py
+++ b/casepro/utils/tests.py
@@ -16,6 +16,7 @@ from casepro.test import BaseCasesTest
 
 from . import safe_max, normalize, match_keywords, truncate, str_to_bool, json_encode, TimelineItem, uuid_to_int
 from . import date_to_milliseconds, datetime_to_microseconds, microseconds_to_datetime, month_range, date_range
+from . import get_language_name
 from .email import send_email
 from .middleware import JSONMiddleware
 
@@ -126,6 +127,14 @@ class UtilsTest(BaseCasesTest):
         """
         self.assertTrue(uuid_to_int(uuid.hex) <= 2147483647)
         self.assertTrue(uuid_to_int(uuid.hex) >= 0)
+
+    def test_get_language_name(self):
+        self.assertEquals('French', get_language_name('fre'))
+        self.assertEquals('French', get_language_name('fre'))  # from cache
+        self.assertEquals('Creoles and pidgins, English based', get_language_name('cpe'))
+
+        # should strip off anything after an open paren or semicolon
+        self.assertEquals('Official Aramaic', get_language_name('arc'))
 
 
 class EmailTest(BaseCasesTest):

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -29,6 +29,7 @@ enum34==1.0.4
 flake8==2.5.4
 gunicorn==19.3.0
 hamlpy==0.82.2
+iso639==0.1.4
 hypothesis==3.4.0
 kombu==3.0.33
 microsofttranslator==0.5

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -20,6 +20,7 @@ enum34
 flake8
 gunicorn
 hamlpy
+iso639
 mock
 pillow
 pisa

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -149,6 +149,11 @@
                   - trans "Name"
                 .contact-field-value.col-sm-6
                   [[ caseObj.contact.name ]]
+              .row{ ng-if:"contact.language" }
+                .contact-field-label.col-sm-6
+                  - trans "Language"
+                .contact-field-value.col-sm-6
+                  [[ contact.language.name ]]
               .row{ ng-repeat:"field in fields" }
                 .contact-field-label.col-sm-6
                   [[ field.label ]]


### PR DESCRIPTION
Also adds language to the contact details box on the case read page:

<img width="337" alt="screen shot 2016-07-22 at 09 38 23" src="https://cloud.githubusercontent.com/assets/675558/17049880/22ff51e6-4ff0-11e6-9647-3f88bdc10621.png">
