### PR TITLE
Restore contact groups on contact read page

### DIFF
--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -274,6 +274,7 @@ class Contact(models.Model):
         result = {'id': self.pk, 'name': self.get_display_name()}
 
         if full:
+            result['groups'] = [g.as_json(full=False) for g in self.groups.all()]
             result['fields'] = self.get_fields(visible=True)
             result['language'] = self.get_language()
 

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -96,6 +96,7 @@ class ContactTest(BaseCasesTest):
             'id': self.ann.pk,
             'name': "Ann",
             'fields': {'nickname': None, 'age': "32"},
+            'groups': [{'id': self.reporters.pk, 'name': "Reporters"}],
             'language': {'code': 'eng', 'name': "English"}
         })
 
@@ -105,6 +106,7 @@ class ContactTest(BaseCasesTest):
         self.assertEqual(self.ann.as_json(full=True), {
             'id': self.ann.pk,
             'name': "Ann",
+            'groups': [{'id': self.reporters.pk, 'name': "Reporters"}],
             'fields': {'nickname': None, 'age': "32"},
             'language': None
         })
@@ -166,6 +168,7 @@ class ContactCRUDLTest(BaseCasesTest):
             'id': self.ann.pk,
             'name': "Ann",
             'fields': {'age': '32', 'nickname': None},
+            'groups': [{'id': self.reporters.pk, 'name': "Reporters"}],
             'language': {'code': 'eng', 'name': "English"}
         })
 

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -39,9 +39,14 @@ describe('controllers:', () ->
       nickname: {key: 'nickname', label: "Nickname", value_type: 'T'},
       age: {key: 'age', label: "Age", value_type: 'N'},
 
+      # groups
+      females: {id: 701, name: "Females"},
+      males: {id: 702, name: "Males"},
+      ureporters: {id: 703, name: "U-Reporters"},
+
       # contacts
-      ann: {id: 401, name: "Ann", fields: {'age': 35}},
-      bob: {id: 402, name: "Bob", fields: {}}
+      ann: {id: 401, name: "Ann", fields: {'age': 35}, groups: [{id: 701, name: "Females"}, {id: 703, name: "U-Reporters"}]},
+      bob: {id: 402, name: "Bob", fields: {}, groups: []}
     }
   )
 
@@ -558,6 +563,10 @@ describe('controllers:', () ->
 
       expect(ContactService.fetchCases).toHaveBeenCalledWith(test.ann)
       expect($scope.cases).toEqual(cases)
+    )
+
+    it('getGroups', () ->
+      expect($scope.getGroups()).toEqual("Females, U-Reporters")
     )
   )
 

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -566,6 +566,8 @@ describe('controllers:', () ->
     )
 
     it('getGroups', () ->
+      console.log($scope.contact)
+
       expect($scope.getGroups()).toEqual("Females, U-Reporters")
     )
   )

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -648,9 +648,7 @@ controllers.controller('ContactController', ['$scope', '$window', 'ContactServic
 
   $scope.contact = $window.contextData.contact
   $scope.fields = $window.contextData.fields
-
-  $scope.contact.groups = []
-
+  
   $scope.init = () ->
     ContactService.fetchCases($scope.contact).then((cases) ->
       $scope.cases = cases

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -649,10 +649,15 @@ controllers.controller('ContactController', ['$scope', '$window', 'ContactServic
   $scope.contact = $window.contextData.contact
   $scope.fields = $window.contextData.fields
 
+  $scope.contact.groups = []
+
   $scope.init = () ->
     ContactService.fetchCases($scope.contact).then((cases) ->
       $scope.cases = cases
     )
+
+  $scope.getGroups = () ->
+    return (g.name for g in $scope.contact.groups).join(", ")
 ])
 
 

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -19,8 +19,6 @@
         %span.glyphicon.glyphicon-phone
         [[ contact.name ]]
 
-      %br
-
     .row
       .col-md-8
         .panel.panel-default
@@ -56,6 +54,15 @@
                   [[ field.label ]]
                 .contact-field-value.col-sm-6
                   <cp-fieldvalue contact="contact" field="field" />
+
+        .panel.panel-default
+          .panel-heading
+            - trans "Groups"
+          .panel-body
+            %span{ ng-if:"contact.groups.length > 0" }
+              [[ getGroups() ]]
+            .none{ ng-if:"contact.groups.length == 0", style:"padding: 0em" }
+              - trans "None"
 
 
 - block extra-style


### PR DESCRIPTION
These were inadvertently removed from this page by https://github.com/rapidpro/casepro/pull/112

<img width="990" alt="screen shot 2016-07-25 at 09 12 29" src="https://cloud.githubusercontent.com/assets/675558/17094929/5922156a-5252-11e6-8792-33b2b4401c76.png">

If contact doesn't belong to any groups:

<img width="305" alt="screen shot 2016-07-25 at 09 42 55" src="https://cloud.githubusercontent.com/assets/675558/17094927/55a535e8-5252-11e6-9e9f-27b2854179a0.png">

