### PR TITLE
Display contact status (blocked and/or stopped)

### DIFF
--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -45,13 +45,18 @@ class ContactSyncer(BaseSyncer):
             'name': remote.name,
             'language': remote.language,
             'is_blocked': remote.blocked,
+            'is_stopped': remote.stopped,
             'is_stub': False,
             'fields': fields,
             Contact.SAVE_GROUPS_ATTR: groups,
         }
 
     def update_required(self, local, remote, remote_as_kwargs):
-        if local.is_stub or local.name != remote.name or local.language != remote.language:
+        if local.is_stub \
+                or local.name != remote.name \
+                or local.language != remote.language \
+                or local.is_blocked != remote.blocked \
+                or local.is_stopped != remote.stopped:
             return True
 
         if {g.uuid for g in local.groups.all()} != {g.uuid for g in remote.groups}:

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -42,6 +42,7 @@ class ContactSyncerTest(BaseCasesTest):
             'name': "Bob McFlow",
             'language': "eng",
             'is_blocked': False,
+            'is_stopped': False,
             'is_stub': False,
             'fields': {'age': "34"},
             '__data__groups': [("G-001", "Customers")],
@@ -60,6 +61,7 @@ class ContactSyncerTest(BaseCasesTest):
             fields={},
             language=None,
             blocked=False,
+            stopped=False,
             modified_on=now()
         ), {}))
 
@@ -78,6 +80,7 @@ class ContactSyncerTest(BaseCasesTest):
             fields={'chat_name': "ann", 'age': None},
             language='eng',
             blocked=False,
+            stopped=False,
             modified_on=now()
         ), {}))
 
@@ -90,6 +93,7 @@ class ContactSyncerTest(BaseCasesTest):
             fields={'chat_name': "ann"},
             language='eng',
             blocked=False,
+            stopped=False,
             modified_on=now()
         ), {}))
 
@@ -102,6 +106,7 @@ class ContactSyncerTest(BaseCasesTest):
             fields={'chat_name': "ann"},
             language='eng',
             blocked=False,
+            stopped=False,
             modified_on=now()
         ), {}))
 
@@ -114,6 +119,7 @@ class ContactSyncerTest(BaseCasesTest):
             fields={'chat_name': "ann8111"},
             language='eng',
             blocked=False,
+            stopped=False,
             modified_on=now()
         ), {}))
 
@@ -126,6 +132,7 @@ class ContactSyncerTest(BaseCasesTest):
             fields={'chat_name': "ann", 'age': "35"},
             language='eng',
             blocked=False,
+            stopped=False,
             modified_on=now()
         ), {}))
 

--- a/casepro/contacts/migrations/0021_contact_is_stopped_pt1.py
+++ b/casepro/contacts/migrations/0021_contact_is_stopped_pt1.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0020_unset_suspend_from_dynamic'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contact',
+            name='is_stopped',
+            field=models.NullBooleanField(help_text='Whether this contact opted out of receiving messages'),
+        ),
+        migrations.AlterField(
+            model_name='contact',
+            name='is_stopped',
+            field=models.NullBooleanField(default=False,
+                                          help_text='Whether this contact opted out of receiving messages'),
+        ),
+    ]

--- a/casepro/contacts/migrations/0022_contact_is_stopped_pt2.py
+++ b/casepro/contacts/migrations/0022_contact_is_stopped_pt2.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from dash.utils import chunks
+from django.db import migrations, models
+
+
+def populate_is_stopped(apps, schema_editor):
+    Contact = apps.get_model('contacts', 'Contact')
+
+    contact_ids = list(Contact.objects.values_list('id', flat=True))
+    num_updated = 0
+
+    for id_batch in chunks(contact_ids, 5000):
+        Contact.objects.filter(pk__in=id_batch).update(is_stopped=False)
+        num_updated += len(id_batch)
+
+        print("Populated is_stopped for %d of %d contacts" % (num_updated, len(contact_ids)))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0021_contact_is_stopped_pt1'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_is_stopped),
+        migrations.AlterField(
+            model_name='contact',
+            name='is_stopped',
+            field=models.BooleanField(default=False, help_text='Whether this contact opted out of receiving messages'),
+        ),
+    ]

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -153,6 +153,8 @@ class Contact(models.Model):
 
     is_blocked = models.BooleanField(default=False, help_text="Whether this contact is blocked")
 
+    is_stopped = models.BooleanField(default=False, help_text="Whether this contact opted out of receiving messages")
+
     is_stub = models.BooleanField(default=False, help_text="Whether this contact is just a stub")
 
     suspended_groups = models.ManyToManyField(Group, help_text=_("Groups this contact has been suspended from"))
@@ -276,6 +278,8 @@ class Contact(models.Model):
         if full:
             result['fields'] = self.get_fields(visible=True)
             result['language'] = self.get_language()
+            result['blocked'] = True # self.is_blocked
+            result['stopped'] = self.is_stopped
 
         return result
 

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -278,7 +278,7 @@ class Contact(models.Model):
         if full:
             result['fields'] = self.get_fields(visible=True)
             result['language'] = self.get_language()
-            result['blocked'] = True # self.is_blocked
+            result['blocked'] = self.is_blocked
             result['stopped'] = self.is_stopped
 
         return result

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -96,7 +96,9 @@ class ContactTest(BaseCasesTest):
             'id': self.ann.pk,
             'name': "Ann",
             'fields': {'nickname': None, 'age': "32"},
-            'language': {'code': 'eng', 'name': "English"}
+            'language': {'code': 'eng', 'name': "English"},
+            'blocked': False,
+            'stopped': False
         })
 
         self.ann.language = None
@@ -106,7 +108,9 @@ class ContactTest(BaseCasesTest):
             'id': self.ann.pk,
             'name': "Ann",
             'fields': {'nickname': None, 'age': "32"},
-            'language': None
+            'language': None,
+            'blocked': False,
+            'stopped': False
         })
 
         # if site uses anon contacts then name is obscured
@@ -166,7 +170,9 @@ class ContactCRUDLTest(BaseCasesTest):
             'id': self.ann.pk,
             'name': "Ann",
             'fields': {'age': '32', 'nickname': None},
-            'language': {'code': 'eng', 'name': "English"}
+            'language': {'code': 'eng', 'name': "English"},
+            'blocked': False,
+            'stopped': False,
         })
 
     def test_cases(self):

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -159,6 +159,18 @@
                   [[ field.label ]]
                 .contact-field-value.col-sm-6
                   <cp-fieldvalue contact="contact" field="field" />
+              .row{ ng-if:"contact.blocked || contact.stopped" }
+                .contact-field-label.col-sm-6
+                  - trans "Status"
+                .contact-field-value.col-sm-6
+                  %span.label-container{ ng-if:"contact.blocked" }
+                    %span.label.label-danger
+                      - trans "Blocked"
+                    &nbsp;
+                  %span.label-container{ ng-if:"contact.stopped" }
+                    %span.label.label-danger
+                      - trans "Stopped"
+                    &nbsp;
           .list-group
             %a.list-group-item.centered{ ng-href:"/contact/read/[[ caseObj.contact.id ]]/" }
               %span.text-primary

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -19,7 +19,19 @@
         %span.glyphicon.glyphicon-phone
         [[ contact.name ]]
 
-      %br
+      %ul.header-details
+        %li{ ng-if:"contact.blocked || contact.stopped" }
+          %strong><
+            - trans "Status"
+          :
+          %span.label-container{ ng-if:"contact.blocked" }
+            %span.label.label-danger
+              - trans "Blocked"
+            &nbsp;
+          %span.label-container{ ng-if:"contact.stopped" }
+            %span.label.label-danger
+              - trans "Stopped"
+            &nbsp;
 
     .row
       .col-md-8


### PR DESCRIPTION
Adds `Contact.is_stopped` and displays both this and `Contact.is_blocked` on the contact and case read pages, if they are set. If they're not set, nothing is displayed so no confusion if these fields aren't being used.

On the contact read page:

<img width="987" alt="screen shot 2016-07-25 at 14 49 15" src="https://cloud.githubusercontent.com/assets/675558/17102193/d9737aee-5278-11e6-8c0a-2b8026877a5a.png">

and on the case page:

<img width="623" alt="screen shot 2016-07-25 at 14 47 34" src="https://cloud.githubusercontent.com/assets/675558/17102196/da3583e6-5278-11e6-9210-cfe5c5de66e3.png">
