### PR TITLE
Fix redirects when creating new users

### DIFF
--- a/casepro/profiles/tests.py
+++ b/casepro/profiles/tests.py
@@ -333,7 +333,7 @@ class UserCRUDLTest(BaseCasesTest):
         response = self.url_post(None, url, {'name': "McAdmin", 'email': "mcadmin@casely.com",
                                              'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, 'http://testserver/user/')
+        self.assertEqual(response.url, 'http://testserver/org/')
 
         user = User.objects.get(email='mcadmin@casely.com')
         self.assertEqual(user.get_full_name(), "McAdmin")
@@ -362,7 +362,7 @@ class UserCRUDLTest(BaseCasesTest):
                                                  'role': ROLE_ADMIN,
                                                  'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, 'http://unicef.localhost/user/')
+        self.assertEqual(response.url, 'http://unicef.localhost/org/home/#/users')
 
         user = User.objects.get(email='adrian@casely.com')
         self.assertEqual(user.get_full_name(), "Adrian Admin")
@@ -393,7 +393,7 @@ class UserCRUDLTest(BaseCasesTest):
                                                  'partner': self.moh.pk, 'role': ROLE_ANALYST,
                                                  'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, 'http://unicef.localhost/user/')
+        self.assertEqual(response.url, 'http://unicef.localhost/partner/read/%d/#/users' % self.moh.pk)
 
         # check new user and profile
         user = User.objects.get(email="mo@casely.com")
@@ -433,7 +433,7 @@ class UserCRUDLTest(BaseCasesTest):
         response = self.url_post('unicef', url, {'name': "Mo Cases", 'email': "mo@casely.com", 'role': ROLE_ANALYST,
                                                  'password': "Qwerty12345", 'confirm_password': "Qwerty12345"})
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, 'http://unicef.localhost/partner/read/%d/' % self.moh.pk)
+        self.assertEqual(response.url, 'http://unicef.localhost/partner/read/%d/#/users' % self.moh.pk)
 
         user = User.objects.get(email='mo@casely.com')
         self.assertEqual(user.profile.partner, self.moh)

--- a/casepro/profiles/views.py
+++ b/casepro/profiles/views.py
@@ -90,6 +90,16 @@ class UserCRUDL(SmartCRUDL):
             else:
                 self.object = Profile.create_user(name, email, password, change_password)
 
+        def get_success_url(self):
+            if self.request.org:
+                partner = self.object.get_partner(self.request.org)
+                if partner:
+                    return reverse('cases.partner_read', args=[partner.pk]) + '#/users'
+                else:
+                    return reverse('orgs_ext.org_home') + '#/users'
+            else:
+                return reverse('orgs_ext.org_list')
+
     class CreateIn(PartnerPermsMixin, OrgFormMixin, SmartCreateView):
         """
         Form for creating partner-level users in a specific partner
@@ -117,7 +127,7 @@ class UserCRUDL(SmartCRUDL):
             self.object = Profile.create_partner_user(org, partner, role, name, email, password, change_password)
 
         def get_success_url(self):
-            return reverse('cases.partner_read', args=[self.kwargs['partner_id']])
+            return reverse('cases.partner_read', args=[self.kwargs['partner_id']]) + '#/users'
 
     class Update(PartnerPermsMixin, UserUpdateMixin, SmartUpdateView):
         """


### PR DESCRIPTION
* Creating a new admin user should redirect to users tab on org dashbaord
* Creating a new partner user should redirect to users tab on partner dashboard

Fixes https://github.com/rapidpro/casepro/issues/120