### PR TITLE
Allow users to belong to different partners in different orgs

### DIFF
--- a/casepro/cases/migrations/0040_partner_users.py
+++ b/casepro/cases/migrations/0040_partner_users.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('cases', '0039_populate_case_watchers'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='partner',
+            name='users',
+            field=models.ManyToManyField(help_text='Users that belong to this partner', related_name='partners', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/casepro/cases/migrations/0041_populate_partner_users.py
+++ b/casepro/cases/migrations/0041_populate_partner_users.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def populate_partner_users(apps, schema_editor):
+    User = apps.get_model('auth', 'User')
+
+    for user in User.objects.exclude(profile__partner=None):
+        partner = user.profile.partner
+        org = partner.org
+
+        if user in org.editors.all() or user in org.viewers.all():
+            partner.users.add(user)
+        else:
+            print("User %s no longer has permissions in org %s to be a partner user" % (user.email, org.name))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cases', '0040_partner_users'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_partner_users)
+    ]

--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -52,6 +52,9 @@ class Partner(models.Model):
     labels = models.ManyToManyField(Label, verbose_name=_("Labels"), related_name='partners',
                                     help_text=_("Labels that this partner can access"))
 
+    users = models.ManyToManyField(User, related_name='partners',
+                                   help_text=_("Users that belong to this partner"))
+
     logo = models.ImageField(verbose_name=_("Logo"), upload_to='partner_logos', null=True, blank=True)
 
     is_active = models.BooleanField(default=True, help_text="Whether this partner is active")
@@ -76,7 +79,7 @@ class Partner(models.Model):
         return self.labels.filter(is_active=True) if self.is_restricted else Label.get_all(self.org)
 
     def get_users(self):
-        return User.objects.filter(profile__partner=self, is_active=True)
+        return self.users.all()
 
     def get_managers(self):
         return self.get_users().filter(org_editors=self.org_id)
@@ -85,9 +88,6 @@ class Partner(models.Model):
         return self.get_users().filter(org_viewers=self.org_id)
 
     def release(self):
-        # detach all users
-        self.user_profiles.update(partner=None)
-
         self.is_active = False
         self.save(update_fields=('is_active',))
 

--- a/casepro/profiles/__init__.py
+++ b/casepro/profiles/__init__.py
@@ -36,6 +36,76 @@ def _user_get_partner(user, org):
     return user.partners.filter(org=org, is_active=True).first()
 
 
+def _user_get_role(user, org):
+    """
+    Gets the role as a character code for this user in the given org
+    """
+    from .models import ROLE_ADMIN, ROLE_MANAGER, ROLE_ANALYST
+
+    if user in org.administrators.all():
+        return ROLE_ADMIN
+    elif user in org.editors.all():
+        return ROLE_MANAGER
+    elif user in org.viewers.all():
+        return ROLE_ANALYST
+    else:
+        return None
+
+
+def _user_update_role(user, org, role, partner=None):
+    """
+    Updates this user's role in the given org
+    """
+    from .models import ROLE_ADMIN, ROLE_MANAGER, ROLE_ANALYST, PARTNER_ROLES
+
+    if partner and partner.org != org:  # pragma: no cover
+        raise ValueError("Can only update partner to partner in same org")
+
+    if role in PARTNER_ROLES and not partner:
+        raise ValueError("Role %s requires a partner org" % role)
+    elif role not in PARTNER_ROLES and partner:
+        raise ValueError("Cannot specify a partner for role %s" % role)
+
+    # remove user from any partners for this org
+    user.partners.remove(*user.partners.filter(org=org))
+
+    if partner:
+        user.partners.add(partner)
+
+    if role == ROLE_ADMIN:
+        org.administrators.add(user)
+        org.editors.remove(user)
+        org.viewers.remove(user)
+    elif role == ROLE_MANAGER:
+        org.administrators.remove(user)
+        org.editors.add(user)
+        org.viewers.remove(user)
+    elif role == ROLE_ANALYST:
+        org.administrators.remove(user)
+        org.editors.remove(user)
+        org.viewers.add(user)
+    else:  # pragma: no cover
+        raise ValueError("Invalid user role: %s" % role)
+
+
+def _user_remove_from_org(user, org):
+    # remove user from all org groups
+    org.administrators.remove(user)
+    org.editors.remove(user)
+    org.viewers.remove(user)
+
+    # remove user from any partners for this org
+    user.partners.remove(*user.partners.filter(org=org))
+
+    # remove as watcher of any case in this org
+    for case in user.watched_cases.filter(org=org):
+        case.unwatch(user)
+
+    # remove as watcher of any label in this org
+    for label in user.watched_labels.filter(org=org):
+        label.unwatch(user)
+
+
 def _user_can_administer(user, org):
     """
     Whether this user can administer the given org
@@ -73,24 +143,6 @@ def _user_can_edit(user, org, other):
     return other_partner and user.can_manage(other_partner)  # manager can edit users in same partner org
 
 
-def _user_remove_from_org(user, org):
-    # remove user from all org groups
-    org.administrators.remove(user)
-    org.editors.remove(user)
-    org.viewers.remove(user)
-
-    # remove user from any partners for this org
-    user.partners.remove(*user.partners.filter(org=org))
-
-    # remove as watcher of any case in this org
-    for case in user.watched_cases.filter(org=org):
-        case.unwatch(user)
-
-    # remove as watcher of any label in this org
-    for label in user.watched_labels.filter(org=org):
-        label.unwatch(user)
-
-
 def _user_unicode(user):
     if user.has_profile():
         if user.profile.full_name:
@@ -106,7 +158,7 @@ def _user_as_json(user, full=True, org=None):
         if org and user.has_profile():
             partner = user.get_partner(org)
             partner_json = partner.as_json(full=False) if partner else None
-            role_json = user.profile.get_role(org)
+            role_json = user.get_role(org)
         else:
             role_json = None
             partner_json = None
@@ -126,6 +178,8 @@ User.clean = _user_clean
 User.has_profile = _user_has_profile
 User.get_full_name = _user_get_full_name
 User.get_partner = _user_get_partner
+User.get_role = _user_get_role
+User.update_role = _user_update_role
 User.can_administer = _user_can_administer
 User.can_manage = _user_can_manage
 User.can_edit = _user_can_edit

--- a/casepro/profiles/migrations/0007_remove_profile_partner.py
+++ b/casepro/profiles/migrations/0007_remove_profile_partner.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0006_notification'),
+        ('cases', '0041_populate_partner_users'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='profile',
+            name='partner',
+        ),
+    ]

--- a/casepro/profiles/tests.py
+++ b/casepro/profiles/tests.py
@@ -173,52 +173,6 @@ class ProfileTest(BaseCasesTest):
         user5 = Profile.create_user("Lou", "lou123456789012345678901234567890@moh.com", "Qwerty123")
         self.assertEqual(user5.email, "lou123456789012345678901234567890@moh.com")
 
-    def test_update_role(self):
-        self.user1.profile.update_role(self.unicef, ROLE_ANALYST, self.who)
-
-        self.assertEqual(set(self.user1.partners.all()), {self.who})
-        self.assertTrue(self.user1 not in self.unicef.administrators.all())
-        self.assertTrue(self.user1 not in self.unicef.editors.all())
-        self.assertTrue(self.user1 in self.unicef.viewers.all())
-
-        self.user1.profile.update_role(self.unicef, ROLE_MANAGER, self.moh)
-
-        self.assertEqual(set(self.user1.partners.all()), {self.moh})
-        self.assertTrue(self.user1 not in self.unicef.administrators.all())
-        self.assertTrue(self.user1 in self.unicef.editors.all())
-        self.assertTrue(self.user1 not in self.unicef.viewers.all())
-
-        self.user1.profile.update_role(self.unicef, ROLE_ADMIN, None)
-
-        self.assertEqual(set(self.user1.partners.all()), set())
-        self.assertIn(self.user1, self.unicef.administrators.all())
-        self.assertNotIn(self.user1, self.unicef.editors.all())
-        self.assertNotIn(self.user1, self.unicef.viewers.all())
-
-        # can add them as partner user in another org without changing admin status in this org
-        self.user1.profile.update_role(self.nyaruka, ROLE_ANALYST, self.klab)
-
-        self.assertEqual(set(self.user1.partners.all()), {self.klab})
-        self.assertIn(self.user1, self.unicef.administrators.all())
-        self.assertNotIn(self.user1, self.unicef.editors.all())
-        self.assertNotIn(self.user1, self.unicef.viewers.all())
-        self.assertNotIn(self.user1, self.nyaruka.administrators.all())
-        self.assertNotIn(self.user1, self.nyaruka.editors.all())
-        self.assertIn(self.user1, self.nyaruka.viewers.all())
-
-        # error if partner provided for non-partner role
-        self.assertRaises(ValueError, self.user1.profile.update_role, self.unicef, ROLE_ADMIN, self.who)
-
-        # error if no partner provided for partner role
-        self.assertRaises(ValueError, self.user1.profile.update_role, self.unicef, ROLE_MANAGER, None)
-
-    def test_get_role(self):
-        self.assertEqual(self.admin.profile.get_role(self.unicef), ROLE_ADMIN)
-        self.assertEqual(self.user1.profile.get_role(self.unicef), ROLE_MANAGER)
-        self.assertEqual(self.user2.profile.get_role(self.unicef), ROLE_ANALYST)
-        self.assertEqual(self.user4.profile.get_role(self.unicef), None)
-        self.assertEqual(self.admin.profile.get_role(self.nyaruka), None)
-
 
 class UserTest(BaseCasesTest):
     def test_has_profile(self):
@@ -230,6 +184,52 @@ class UserTest(BaseCasesTest):
         self.assertEqual(self.superuser.get_full_name(), "")
         self.assertEqual(self.admin.get_full_name(), "Kidus")
         self.assertEqual(self.user1.get_full_name(), "Evan")
+
+    def test_get_role(self):
+        self.assertEqual(self.admin.get_role(self.unicef), ROLE_ADMIN)
+        self.assertEqual(self.user1.get_role(self.unicef), ROLE_MANAGER)
+        self.assertEqual(self.user2.get_role(self.unicef), ROLE_ANALYST)
+        self.assertEqual(self.user4.get_role(self.unicef), None)
+        self.assertEqual(self.admin.get_role(self.nyaruka), None)
+
+    def test_update_role(self):
+        self.user1.update_role(self.unicef, ROLE_ANALYST, self.who)
+
+        self.assertEqual(set(self.user1.partners.all()), {self.who})
+        self.assertTrue(self.user1 not in self.unicef.administrators.all())
+        self.assertTrue(self.user1 not in self.unicef.editors.all())
+        self.assertTrue(self.user1 in self.unicef.viewers.all())
+
+        self.user1.update_role(self.unicef, ROLE_MANAGER, self.moh)
+
+        self.assertEqual(set(self.user1.partners.all()), {self.moh})
+        self.assertTrue(self.user1 not in self.unicef.administrators.all())
+        self.assertTrue(self.user1 in self.unicef.editors.all())
+        self.assertTrue(self.user1 not in self.unicef.viewers.all())
+
+        self.user1.update_role(self.unicef, ROLE_ADMIN, None)
+
+        self.assertEqual(set(self.user1.partners.all()), set())
+        self.assertIn(self.user1, self.unicef.administrators.all())
+        self.assertNotIn(self.user1, self.unicef.editors.all())
+        self.assertNotIn(self.user1, self.unicef.viewers.all())
+
+        # can add them as partner user in another org without changing admin status in this org
+        self.user1.update_role(self.nyaruka, ROLE_ANALYST, self.klab)
+
+        self.assertEqual(set(self.user1.partners.all()), {self.klab})
+        self.assertIn(self.user1, self.unicef.administrators.all())
+        self.assertNotIn(self.user1, self.unicef.editors.all())
+        self.assertNotIn(self.user1, self.unicef.viewers.all())
+        self.assertNotIn(self.user1, self.nyaruka.administrators.all())
+        self.assertNotIn(self.user1, self.nyaruka.editors.all())
+        self.assertIn(self.user1, self.nyaruka.viewers.all())
+
+        # error if partner provided for non-partner role
+        self.assertRaises(ValueError, self.user1.update_role, self.unicef, ROLE_ADMIN, self.who)
+
+        # error if no partner provided for partner role
+        self.assertRaises(ValueError, self.user1.update_role, self.unicef, ROLE_MANAGER, None)
 
     def test_can_administer(self):
         # superusers can administer any org
@@ -299,7 +299,7 @@ class UserTest(BaseCasesTest):
         case.watchers.add(self.admin, self.user1)
 
         # add our admin as a partner user in a different org
-        self.admin.profile.update_role(self.nyaruka, ROLE_ANALYST, self.klab)
+        self.admin.update_role(self.nyaruka, ROLE_ANALYST, self.klab)
 
         # have users watch a label too
         self.pregnancy.watchers.add(self.admin, self.user1)

--- a/casepro/profiles/tests.py
+++ b/casepro/profiles/tests.py
@@ -298,6 +298,9 @@ class UserTest(BaseCasesTest):
         case = self.create_case(self.unicef, ann, self.moh, msg, [self.aids], summary="Summary")
         case.watchers.add(self.admin, self.user1)
 
+        # add our admin as a partner user in a different org
+        self.admin.profile.update_role(self.nyaruka, ROLE_ANALYST, self.klab)
+
         # have users watch a label too
         self.pregnancy.watchers.add(self.admin, self.user1)
 
@@ -307,6 +310,10 @@ class UserTest(BaseCasesTest):
         self.admin.refresh_from_db()
         self.assertIsNone(self.unicef.get_user_org_group(self.admin))
         self.assertNotIn(self.admin, case.watchers.all())
+
+        # their status in other org shouldn't be affected
+        self.assertIn(self.admin, self.nyaruka.viewers.all())
+        self.assertIn(self.admin, self.klab.users.all())
 
         # try with partner user
         self.user1.remove_from_org(self.unicef)

--- a/casepro/profiles/views.py
+++ b/casepro/profiles/views.py
@@ -26,7 +26,7 @@ class UserUpdateMixin(OrgFormMixin):
         initial = super(UserUpdateMixin, self).derive_initial()
         initial['name'] = self.object.profile.full_name
         if self.request.org:
-            initial['role'] = self.object.profile.get_role(self.request.org)
+            initial['role'] = self.object.get_role(self.request.org)
             initial['partner'] = self.object.get_partner(self.request.org)
         return initial
 
@@ -40,7 +40,7 @@ class UserUpdateMixin(OrgFormMixin):
         if 'role' in data:
             role = data['role']
             partner = data['partner'] if 'partner' in data else self.get_partner()
-            obj.profile.update_role(self.request.org, role, partner)
+            obj.update_role(self.request.org, role, partner)
 
         # set new password if provided
         password = data['new_password']


### PR DESCRIPTION
Replaces `Profile.partner` with `User.partners` / `Partner.users` many-to-many.

Users can still only be in one partner in a given org - but they can be in a partner in one org - and in another partner in another org.

Also moves `get_role` and `update_role` onto `User` class as `user.get_role(..)` makes more sense than `user.profile.get_role(..)` etc