### PR TITLE
Fix pod rendering

### DIFF
--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -183,7 +183,7 @@
             ng-controller:"{{ pod.pod_type.controller }}",
             ng-init:'init && init({{ pod.config.index }}, {{ case_id }}, {{ pod.config_json }})'
           }
-          <{{ pod.pod_type.directive }} />
+            <{{ pod.pod_type.directive }} />
 
 - block extra-script
   {{ block.super }}


### PR DESCRIPTION
A recent change caused pod directives to no longer get their controller's scope anymore since the directive is no longer a child of the element to which the controller is applied.