### PR TITLE
RapidPro email forward sending using the CasePro email system

### DIFF
--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -8,6 +8,7 @@ from django.utils.timezone import now
 
 from casepro.contacts.models import Contact, Group, Field
 from casepro.msgs.models import Label, Message, Outgoing
+from casepro.utils.email import send_raw_email
 
 from . import BaseBackend
 
@@ -256,10 +257,19 @@ class RapidProBackend(BaseBackend):
     def push_outgoing(self, org, outgoing, as_broadcast=False):
         client = self._get_client(org, 1)
 
+        # RapidPro currently doesn't send emails so we use the CasePro email system to send those instead
+        for_backend = []
+        for msg in outgoing:
+            if msg.urn and msg.urn.startswith('mailto:'):
+                to_address = msg.urn.split(':', 1)[1]
+                send_raw_email([to_address], "New message", msg.text, None)
+            else:
+                for_backend.append(msg)
+
         if as_broadcast:
             contact_uuids = []
             urns = []
-            for msg in outgoing:
+            for msg in for_backend:
                 if msg.contact:
                     contact_uuids.append(msg.contact.uuid)
                 if msg.urn:
@@ -267,12 +277,12 @@ class RapidProBackend(BaseBackend):
             text = outgoing[0].text
             broadcast = client.create_broadcast(text=text, contacts=contact_uuids, urns=urns)
 
-            for msg in outgoing:
+            for msg in for_backend:
                 msg.backend_broadcast_id = broadcast.id
 
-            Outgoing.objects.filter(pk__in=[o.id for o in outgoing]).update(backend_broadcast_id=broadcast.id)
+            Outgoing.objects.filter(pk__in=[o.id for o in for_backend]).update(backend_broadcast_id=broadcast.id)
         else:
-            for msg in outgoing:
+            for msg in for_backend:
                 contact_uuids = [msg.contact.uuid] if msg.contact else []
                 urns = [msg.urn] if msg.urn else []
                 broadcast = client.create_broadcast(text=msg.text, contacts=contact_uuids, urns=urns)

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -635,8 +635,9 @@ class RapidProBackendTest(BaseCasesTest):
 
         mock_create_label.assert_called_once_with(name="Tea")
 
+    @patch('casepro.backend.rapidpro.send_raw_email')
     @patch('dash.orgs.models.TembaClient1.create_broadcast')
-    def test_push_outgoing(self, mock_create_broadcast):
+    def test_push_outgoing(self, mock_create_broadcast, mock_send_raw_email):
         # test with replies sent separately
         mock_create_broadcast.side_effect = [
             TembaBroadcast.create(id=201, text="That's great", urns=[], contacts=["C-001"]),
@@ -682,14 +683,19 @@ class RapidProBackendTest(BaseCasesTest):
 
         out5 = self.create_outgoing(self.unicef, self.user1, None, 'F', "FYI", None, urn="tel:+1234")
         out6 = self.create_outgoing(self.unicef, self.user1, None, 'F', "FYI", None, urn="tel:+2345")
-        self.backend.push_outgoing(self.unicef, [out5, out6], as_broadcast=True)
+        out7 = self.create_outgoing(self.unicef, self.user1, None, 'F', "FYI", None, urn="mailto:jim@unicef.org")
+        self.backend.push_outgoing(self.unicef, [out5, out6, out7], as_broadcast=True)
 
         mock_create_broadcast.assert_called_once_with(text="FYI", contacts=[], urns=["tel:+1234", "tel:+2345"])
 
         out5.refresh_from_db()
         out6.refresh_from_db()
+        out7.refresh_from_db()
         self.assertEqual(out5.backend_broadcast_id, 204)
         self.assertEqual(out6.backend_broadcast_id, 204)
+        self.assertIsNone(out7.backend_broadcast_id)  # emails aren't sent by backend
+
+        mock_send_raw_email.assert_called_once_with(['jim@unicef.org'], "New message", "FYI", None)
 
     @patch('dash.orgs.models.TembaClient1.add_contacts')
     def test_add_to_group(self, mock_add_contacts):

--- a/casepro/utils/email.py
+++ b/casepro/utils/email.py
@@ -10,7 +10,20 @@ from django.conf import settings
 
 def send_email(recipients, subject, template, context):
     """
-    Sends a multi-part (text and HTML) email to a list of users or email addresses
+    Sends a multi-part (text and optionally HTML) email generated from templates
+    """
+    html_template = loader.get_template(template + ".html")
+    text_template = loader.get_template(template + ".txt")
+
+    html = html_template.render(Context(context))
+    text = text_template.render(Context(context))
+
+    send_raw_email(recipients, subject, text, html)
+
+
+def send_raw_email(recipients, subject, text, html):
+    """
+    Sends and multi-part (text and optionally HTML) email to a list of users or email addresses
     """
     to_addresses = []
     for recipient in recipients:
@@ -23,20 +36,13 @@ def send_email(recipients, subject, template, context):
 
     from_address = getattr(settings, 'DEFAULT_FROM_EMAIL', 'website@casepro.io')
 
-    html_template = loader.get_template(template + ".html")
-    text_template = loader.get_template(template + ".txt")
-
-    context['subject'] = subject
-
-    html = html_template.render(Context(context))
-    text = text_template.render(Context(context))
-
     if getattr(settings, 'SEND_EMAILS', False):
         # send individual messages so as to not leak users email addresses, but use bulk send operation for speed
         messages = []
         for to_address in to_addresses:
             message = EmailMultiAlternatives(subject, text, from_email=from_address, to=[to_address])
-            message.attach_alternative(html, "text/html")
+            if html:
+                message.attach_alternative(html, "text/html")
             messages.append(message)
 
         get_connection().send_messages(messages)
@@ -44,5 +50,6 @@ def send_email(recipients, subject, template, context):
         print("FAKE SENDING this email to %s:" % ", ".join(to_addresses))
         print("--------------------------------------- text -----------------------------------------")
         print(text)
-        print("--------------------------------------- html -----------------------------------------")
-        print(html)
+        if html:
+            print("--------------------------------------- html -----------------------------------------")
+            print(html)

--- a/static/coffee/modals.coffee
+++ b/static/coffee/modals.coffee
@@ -4,7 +4,7 @@
 
 modals = angular.module('cases.modals', []);
 
-URN_SCHEMES = {tel: "Phone", twitter: "Twitter", email: "Email"}
+URN_SCHEMES = {tel: "Phone", twitter: "Twitter", mailto: "Email"}
 
 
 #=====================================================================

--- a/templates/partials/modal_compose.haml
+++ b/templates/partials/modal_compose.haml
@@ -21,7 +21,7 @@
                 %a{ ng-click:'setScheme("twitter")' }
                   - trans "Twitter"
               %li
-                %a{ ng-click:'setScheme("email")' }
+                %a{ ng-click:'setScheme("mailto")' }
                   - trans "Email"
           %input.form-control{ type:"text", ng-model:"fields.urn.path", name:"path", required:"", style:"width: 300px" }
         .help-block{ ng-show:"form.path.$error.required && (form.path.$dirty || form.submitted)" }


### PR DESCRIPTION
UPartners want to be able to forward messages to phone numbers and email addresses, but RapidPro doesn't currently support email channels. 

This change allows the RapidPro backend to handle mailto: URNs by leveraging the internal CasePro email system.

Also switches email URN prefix to "mailto:"