### PR TITLE
Render URNs on forwards in Sent messages folder

### DIFF
--- a/karma/test-directives.coffee
+++ b/karma/test-directives.coffee
@@ -305,6 +305,41 @@ describe('directives:', () ->
   )
 
   #=======================================================================
+  # Tests for URN
+  #=======================================================================
+  describe('cpUrn', () ->
+    it('formats a URN as a link', () ->
+      $scope = $rootScope.$new()
+      $scope.urn = 'tel:+11234567890'
+
+      el = $compile('<cp-urn urn="urn" />')($scope)[0]
+      $rootScope.$digest()
+
+      link = el.querySelector('a')
+      expect(link.href).toEqual('tel:+11234567890')
+      expect(link.textContent).toEqual('+11234567890')
+
+      $scope.urn = 'twitter:bobby'
+
+      el = $compile('<cp-urn urn="urn" />')($scope)[0]
+      $rootScope.$digest()
+
+      link = el.querySelector('a')
+      expect(link.href).toEqual('https://twitter.com/bobby')
+      expect(link.textContent).toEqual('bobby')
+
+      $scope.urn = 'mailto:jim@unicef.org'
+
+      el = $compile('<cp-urn urn="urn" />')($scope)[0]
+      $rootScope.$digest()
+
+      link = el.querySelector('a')
+      expect(link.href).toEqual('mailto:jim@unicef.org')
+      expect(link.textContent).toEqual('jim@unicef.org')
+    )
+  )
+
+  #=======================================================================
   # Tests for cpAlert
   #=======================================================================
   describe('cpAlert', () ->

--- a/static/coffee/directives.coffee
+++ b/static/coffee/directives.coffee
@@ -68,17 +68,16 @@ directives.directive('cpAlerts', -> {
 })
 
 
-#=====================================================================
+#----------------------------------------------------------------------------
 # Pod directive
-#=====================================================================
+#----------------------------------------------------------------------------
 directives.directive('cpPod', -> {
   templateUrl: -> '/sitestatic/templates/pod.html'
 })
 
-#=====================================================================
-# Tooltip directive
-# Shows 'displayText' with a tooltip at 'position' containing 'tooltipText'
-#=====================================================================
+#----------------------------------------------------------------------------
+# Date formatter
+#----------------------------------------------------------------------------
 directives.directive('cpDate', () ->
   return {
     restrict: 'E',
@@ -87,5 +86,26 @@ directives.directive('cpDate', () ->
     controller: ($scope) ->
         if $scope.tooltipPosition is undefined
             $scope.tooltipPosition = "top-right";
+  }
+)
+
+#----------------------------------------------------------------------------
+# URN as link renderer
+#----------------------------------------------------------------------------
+directives.directive('cpUrn', () ->
+  return {
+    restrict: 'E',
+    scope: {urn: '='},
+    template: '<a href="[[ link ]]">[[ path ]]</a>',
+    controller: ['$scope', ($scope) ->
+        parts = $scope.urn.split(':')
+        $scope.scheme = parts[0]
+        $scope.path = parts[1]
+
+        if $scope.scheme == 'twitter'
+          $scope.link = 'https://twitter.com/' + $scope.path
+        else
+          $scope.link = $scope.urn
+    ]
   }
 )

--- a/templates/cases/inbox_outgoing.haml
+++ b/templates/cases/inbox_outgoing.haml
@@ -42,8 +42,7 @@
             %a{ ng-click:"activateContact(item.contact)", style:"white-space: nowrap;" }><
               <cp-contact contact="item.contact" fields="fields">
           %span{ ng-if:"item.urn" }
-            %strong><
-              <cp-urn urn="item.urn" />
+            <cp-urn urn="item.urn" />
 
         .message-text
           %span.label-container{ ng-if:"item.case" }

--- a/templates/cases/inbox_outgoing.haml
+++ b/templates/cases/inbox_outgoing.haml
@@ -41,9 +41,9 @@
           %span{ ng-if:"item.contact" }
             %a{ ng-click:"activateContact(item.contact)", style:"white-space: nowrap;" }><
               <cp-contact contact="item.contact" fields="fields">
-          %span{ ng-if:"item.urns.length" }
-            <ng-pluralize count="item.urns.length" when="{'one': '1 recipient', 'other': '{} recipients'}">
-            </ng-pluralize>
+          %span{ ng-if:"item.urn" }
+            %strong><
+              <cp-urn urn="item.urn" />
 
         .message-text
           %span.label-container{ ng-if:"item.case" }


### PR DESCRIPTION
Introduces a `cp-urn` directive to format URNs as a link