### PR TITLE
Fix wrapping of message text when it doesn't contain spaces

### DIFF
--- a/templates/cases/inbox_messages.haml
+++ b/templates/cases/inbox_messages.haml
@@ -215,6 +215,8 @@
     }
     .message-text {
       margin-left: 130px;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
     }
     .message-actions .flag {
       color: #ddd;

--- a/templates/cases/partner_read.haml
+++ b/templates/cases/partner_read.haml
@@ -130,7 +130,7 @@
                       [[ item.text ]]
                     %td
                       <span ng-class="{'time-warning': item.response.warning}">[[ item.response.delay ]]</span>
-                    %td
+                    %td.message-text
                       %span.label-container{ ng-if:"item.case" }
                         %span.label.label-warning
                           [[ item.case.assignee.name ]]
@@ -228,4 +228,11 @@
     #chart-replies-by-month {
       width: 100%;
       height: 250px;
+    }
+
+    .message-text {
+      /* forces wrapping of messages with no spaces */
+      max-width: 400px;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
     }


### PR DESCRIPTION
Sometimes.people.send.messages.like.this.perhaps.because.their.phone.doesnt.have.a.space.key.and.then.we.have.wrapping.problems.