### PR TITLE
Django 1.9

### DIFF
--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -1105,16 +1105,16 @@ class PartnerCRUDLTest(BaseCasesTest):
 
         # post name change
         response = self.url_post('unicef', url, {'name': "MOH2"})
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, 'http://unicef.localhost/partner/read/%d/' % self.moh.pk)
+        self.assertRedirects(response, 'http://unicef.localhost/partner/read/%d/' % self.moh.pk,
+                             fetch_redirect_response=False)
 
         moh = Partner.objects.get(pk=self.moh.pk)
         self.assertEqual(moh.name, "MOH2")
 
         # post primary contact change
         response = self.url_post('unicef', url, {'name': "MOH", 'primary_contact': self.user1.pk})
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, 'http://unicef.localhost/partner/read/%d/' % self.moh.pk)
+        self.assertRedirects(response, 'http://unicef.localhost/partner/read/%d/' % self.moh.pk,
+                             fetch_redirect_response=False)
 
         moh = Partner.objects.get(pk=self.moh.pk)
         self.assertEqual(moh.primary_contact, self.user1)

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -281,8 +281,8 @@ TEMPLATES = [
                 'casepro.profiles.context_processors.user',
             ],
             'loaders': [
-                'hamlpy.template.loaders.HamlPyFilesystemLoader',
-                'hamlpy.template.loaders.HamlPyAppDirectoriesLoader',
+                'dash.utils.haml.HamlFilesystemLoader',
+                'dash.utils.haml.HamlAppDirectoriesLoader',
                 'django.template.loaders.filesystem.Loader',
                 'django.template.loaders.app_directories.Loader'
             ],

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -1,4 +1,4 @@
-Django==1.8.15
+Django==1.9.10
 Markdown==2.6.2
 Pillow==2.9.0
 Pygments==2.0.2


### PR DESCRIPTION
Most of the Django 1.9 required changes went into https://github.com/rapidpro/casepro/pull/160 so this just switches to the new custom HAML template loaders in Dash, and fixes a couple of redirect related unit tests.