### PR TITLE
Fix Redis location URL format

### DIFF
--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -142,7 +142,7 @@ ROOT_URLCONF = 'casepro.urls'
 CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': '127.0.0.1:6379:15',
+        'LOCATION': 'redis://127.0.0.1:6379/15',
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
         }


### PR DESCRIPTION
django-redis 3.8 introduced support for redis-py style URLs - seems old format is silently ignored