### PR TITLE
More user assignment tweaks

### DIFF
--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -151,24 +151,18 @@ describe('controllers:', () ->
       reassignModal = spyOnPromise($q, $scope, UtilsService, 'assignModal')
       reassignCase = spyOnPromise($q, $scope, CaseService, 'reassign')
       partnerFetch = spyOnPromise($q, $scope, PartnerService, 'fetchAll')
-      usersForPartner = spyOnPromise($q, $scope, UserService, 'fetchInPartner')
-
 
       $scope.caseObj = test.case1
       $scope.onReassign()
 
       partnerFetch.resolve([test.moh, test.who])
-      usersForPartner.resolve([test.user1])
       reassignModal.resolve({assignee: test.moh, user: test.user1})
       reassignCase.resolve()
 
       # List of partners should be fetched
       expect(PartnerService.fetchAll).toHaveBeenCalled()
-      # List of users for first partner should be fetched
-      expect(UserService.fetchInPartner).toHaveBeenCalledWith(test.moh, true)
       # Modal should be sent list of partners and list of users for first partner
-      expect(UtilsService.assignModal).toHaveBeenCalledWith(
-        'Re-assign', null, [test.moh, test.who], [test.user1])
+      expect(UtilsService.assignModal).toHaveBeenCalledWith('Re-assign', null, [test.moh, test.who])
       # Result of modal selection should be sent to reassign the case
       expect(CaseService.reassign).toHaveBeenCalledWith(test.case1, test.moh, test.user1)
     )
@@ -470,17 +464,14 @@ describe('controllers:', () ->
           fetchPartners = spyOnPromise($q, $scope, PartnerService, 'fetchAll')
           newCaseModal = spyOnPromise($q, $scope, UtilsService, 'newCaseModal')
           openCase = spyOnPromise($q, $scope, CaseService, 'open')
-          fetchUsersForPartner = spyOnPromise($q, $scope, UserService, 'fetchInPartner')
           spyOn(UtilsService, 'navigate')
 
           $scope.onCaseFromMessage(test.msg1)
 
           fetchPartners.resolve([test.moh, test.who])
-          fetchUsersForPartner.resolve([test.user1])
           newCaseModal.resolve({summary: "New case", assignee: test.moh, user: test.user1})
           openCase.resolve({id: 601, summary: "New case", isNew: false})
 
-          expect(UserService.fetchInPartner).toHaveBeenCalledWith(test.moh, true)
           expect(CaseService.open).toHaveBeenCalledWith(test.msg1, "New case", test.moh, test.user1)
           expect(UtilsService.navigate).toHaveBeenCalledWith('/case/read/601/?alert=open_found_existing')
         )

--- a/karma/test-modals.coffee
+++ b/karma/test-modals.coffee
@@ -46,11 +46,11 @@ describe('modals:', () ->
   )
 
   it('AssignModalController', () ->
-    $controller('AssignModalController', {$scope: $scope, $uibModalInstance: modalInstance, title: "Title", prompt: "OK?", partners: [test.moh, test.who], users: [test.user1]})
+    $controller('AssignModalController', {$scope: $scope, $uibModalInstance: modalInstance, title: "Title", prompt: "OK?", partners: [test.moh, test.who]})
 
     expect($scope.fields.assignee).toEqual(test.moh)
     expect($scope.fields.user).toEqual({id: null, name: "-- Anyone --"})
-    expect($scope.users).toEqual([{id: null, name: "-- Anyone --"}, test.user1])
+    expect($scope.users).toEqual([{id: null, name: "-- Anyone --"}])
 
     $scope.fields.assignee = test.who
     $scope.fields.user = test.user1
@@ -65,9 +65,9 @@ describe('modals:', () ->
   )
 
   it('AssignModalController.refreshUserList', () ->
-    $controller('AssignModalController', {$scope: $scope, $uibModalInstance: modalInstance, title: "Title", prompt: "OK?", partners: [test.moh, test.who], users: []})
-
     usersForPartner = spyOnPromise($q, $scope, UserService, 'fetchInPartner')
+
+    $controller('AssignModalController', {$scope: $scope, $uibModalInstance: modalInstance, title: "Title", prompt: "OK?", partners: [test.moh, test.who]})
 
     expect($scope.users).toEqual([{id: null, name: "-- Anyone --"}])
 
@@ -75,6 +75,7 @@ describe('modals:', () ->
     usersForPartner.resolve([test.user1])
 
     expect($scope.users).toEqual([{id: null, name: "-- Anyone --"}, test.user1])
+    expect(UserService.fetchInPartner).toHaveBeenCalledWith(test.moh, false)
   )
 
   it('ComposeModalController', () ->
@@ -157,13 +158,13 @@ describe('modals:', () ->
   )
 
   it('NewCaseModalController', () ->
-    $controller('NewCaseModalController', {$scope: $scope, $uibModalInstance: modalInstance, summaryInitial: "Hello", summaryMaxLength: 10, partners: [test.moh, test.who], users: [test.user1]})
+    $controller('NewCaseModalController', {$scope: $scope, $uibModalInstance: modalInstance, summaryInitial: "Hello", summaryMaxLength: 10, partners: [test.moh, test.who]})
 
     expect($scope.fields.summary).toEqual({val: "Hello", maxLength: 10})
     expect($scope.fields.assignee).toEqual({val: test.moh})
     expect($scope.fields.user).toEqual({val: {id: null, name: "-- Anyone --"}})
     expect($scope.partners).toEqual([test.moh, test.who])
-    expect($scope.users).toEqual([{id: null, name: "-- Anyone --"}].concat([test.user1]))
+    expect($scope.users).toEqual([{id: null, name: "-- Anyone --"}])
 
     $scope.fields.summary.val = "Interesting"
     $scope.fields.assignee.val = test.who
@@ -179,9 +180,9 @@ describe('modals:', () ->
   )
 
   it('NewCaseModalController.refreshUserList', () ->
-    $controller('NewCaseModalController', {$scope: $scope, $uibModalInstance: modalInstance, summaryInitial: "Hello", summaryMaxLength: 10, partners: [test.moh, test.who], users: []})
-
     usersForPartner = spyOnPromise($q, $scope, UserService, 'fetchInPartner')
+
+    $controller('NewCaseModalController', {$scope: $scope, $uibModalInstance: modalInstance, summaryInitial: "Hello", summaryMaxLength: 10, partners: [test.moh, test.who]})
 
     expect($scope.users).toEqual([{id: null, name: "-- Anyone --"}])
 
@@ -189,6 +190,7 @@ describe('modals:', () ->
     usersForPartner.resolve([test.user1])
 
     expect($scope.users).toEqual([{id: null, name: "-- Anyone --"}, test.user1])
+    expect(UserService.fetchInPartner).toHaveBeenCalledWith(test.moh, false)
   )
 
   it('NoteModalController', () ->

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -362,15 +362,12 @@ controllers.controller('MessagesController', ['$scope', '$timeout', '$uibModal',
     }})
 
   newCaseFromMessage = (message, possibleAssignees) ->
-    assignee = if possibleAssignees then possibleAssignees[0] else null
-    UserService.fetchInPartner(assignee, true).then((users) ->
-      UtilsService.newCaseModal(message.text, CASE_SUMMARY_MAX_LEN, possibleAssignees, users).then((data) ->
-        CaseService.open(message, data.summary, data.assignee, data.user).then((caseObj) ->
-            caseUrl = '/case/read/' + caseObj.id + '/'
-            if !caseObj.is_new
-              caseUrl += '?alert=open_found_existing'
-            UtilsService.navigate(caseUrl)
-        )
+    UtilsService.newCaseModal(message.text, CASE_SUMMARY_MAX_LEN, possibleAssignees).then((data) ->
+      CaseService.open(message, data.summary, data.assignee, data.user).then((caseObj) ->
+          caseUrl = '/case/read/' + caseObj.id + '/'
+          if !caseObj.is_new
+            caseUrl += '?alert=open_found_existing'
+          UtilsService.navigate(caseUrl)
       )
     )
 ])
@@ -635,12 +632,10 @@ controllers.controller('CaseController', ['$scope', '$window', '$timeout', 'Case
 
   $scope.onReassign = () ->
     PartnerService.fetchAll().then((partners) ->
-      UserService.fetchInPartner(partners[0], true).then((users) ->
-        UtilsService.assignModal("Re-assign", null, partners, users).then((result) ->
-          {assignee, user} = result
-          CaseService.reassign($scope.caseObj, assignee, user).then(() ->
-            $scope.$broadcast('timelineChanged')
-          )
+      UtilsService.assignModal("Re-assign", null, partners).then((result) ->
+        {assignee, user} = result
+        CaseService.reassign($scope.caseObj, assignee, user).then(() ->
+          $scope.$broadcast('timelineChanged')
         )
       )
     )

--- a/static/coffee/modals.coffee
+++ b/static/coffee/modals.coffee
@@ -5,6 +5,7 @@
 modals = angular.module('cases.modals', []);
 
 URN_SCHEMES = {tel: "Phone", twitter: "Twitter", mailto: "Email"}
+ANYONE = {id: null, name: "-- Anyone --"}
 
 
 #=====================================================================
@@ -73,23 +74,20 @@ modals.controller('ReplyModalController', ['$scope', '$uibModalInstance', 'selec
 #=====================================================================
 # Open new case modal
 #=====================================================================
-modals.controller 'NewCaseModalController', ['$scope', '$uibModalInstance', 'summaryInitial', 'summaryMaxLength', 'partners', 'users', 'UserService', ($scope, $uibModalInstance, summaryInitial, summaryMaxLength, partners, users, UserService) ->
+modals.controller 'NewCaseModalController', ['$scope', '$uibModalInstance', 'summaryInitial', 'summaryMaxLength', 'partners', 'UserService', ($scope, $uibModalInstance, summaryInitial, summaryMaxLength, partners, UserService) ->
   $scope.partners = partners
-
-  userListFromUsers = (users) ->
-    return [{id: null, name: "-- Anyone --"}].concat(users)
-
-  $scope.users = userListFromUsers(users)
+  $scope.users = [ANYONE]
 
   $scope.fields = {
     summary: {val: summaryInitial, maxLength: summaryMaxLength},
     assignee: {val: if partners then partners[0] else null},
-    user: {val: $scope.users[0]}
+    user: {val: ANYONE}
   }
 
   $scope.refreshUserList = () ->
-    UserService.fetchInPartner($scope.fields.assignee.val, true).then((users) ->
-      $scope.users = userListFromUsers(users)
+    UserService.fetchInPartner($scope.fields.assignee.val, false).then((users) ->
+      $scope.users = [ANYONE].concat(users)
+      $scope.fields.user.val = ANYONE
     )
 
   $scope.ok = () ->
@@ -98,33 +96,38 @@ modals.controller 'NewCaseModalController', ['$scope', '$uibModalInstance', 'sum
       $uibModalInstance.close({
         summary: $scope.fields.summary.val,
         assignee: $scope.fields.assignee.val,
-        user: $scope.fields.user.val
+        user: if $scope.fields.user.val.id then $scope.fields.user.val else null
       })
   $scope.cancel = () -> $uibModalInstance.dismiss(false)
+
+  $scope.refreshUserList()
 ]
 
 
 #=====================================================================
 # Assign to partner modal
 #=====================================================================
-modals.controller 'AssignModalController', ['$scope', '$uibModalInstance', 'title', 'prompt', 'partners', 'users', 'UserService', ($scope, $uibModalInstance, title, prompt, partners, users, UserService) ->
+modals.controller 'AssignModalController', ['$scope', '$uibModalInstance', 'title', 'prompt', 'partners', 'UserService', ($scope, $uibModalInstance, title, prompt, partners, UserService) ->
   $scope.title = title
   $scope.prompt = prompt
   $scope.partners = partners
+  $scope.users = [ANYONE]
 
-  userListFromUsers = (users) ->
-    return [{id: null, name: "-- Anyone --"}].concat(users)
-
-  $scope.users = userListFromUsers(users)
-  $scope.fields = { assignee: partners[0], user: $scope.users[0] }
+  $scope.fields = { assignee: partners[0], user: ANYONE }
 
   $scope.refreshUserList = () ->
-    UserService.fetchInPartner($scope.fields.assignee, true).then((users) ->
-      $scope.users = userListFromUsers(users)
+    UserService.fetchInPartner($scope.fields.assignee, false).then((users) ->
+      $scope.users = [ANYONE].concat(users)
+      $scope.fields.user = ANYONE
     )
 
-  $scope.ok = () -> $uibModalInstance.close({assignee: $scope.fields.assignee, user: $scope.fields.user})
+  $scope.ok = () -> $uibModalInstance.close({
+    assignee: $scope.fields.assignee,
+    user: if $scope.fields.user.id then $scope.fields.user else null
+  })
   $scope.cancel = () -> $uibModalInstance.dismiss(false)
+
+  $scope.refreshUserList()
 ]
 
 


### PR DESCRIPTION
Changes new case and re-assign modals so they are responsible for fetching users. Right now the calling code fetches users initially, and the modal refreshes them if the partner selection changes - simpler to always have the modal do the fetching.