### PR TITLE
Remove django-celery as it's not needed

### DIFF
--- a/casepro/celery.py
+++ b/casepro/celery.py
@@ -10,14 +10,6 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'casepro.settings')
 
 app = Celery('casepro')
 
-# use django-celery database backend
-app.conf.update(
-    CELERY_RESULT_BACKEND='djcelery.backends.cache:CacheBackend',
-    CELERY_ACCEPT_CONTENT=['json'],
-    CELERY_TASK_SERIALIZER='json',
-    CELERY_RESULT_SERIALIZER='json',
-)
-
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings')

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import djcelery
 import os
 import sys
 
@@ -165,7 +164,6 @@ INSTALLED_APPS = (
     'django.contrib.postgres',
     'django_comments',
 
-    'djcelery',
     'djcelery_email',
 
     # mo-betta permission management
@@ -459,8 +457,6 @@ INTERNAL_IPS = ('127.0.0.1',)
 # -----------------------------------------------------------------------------------
 # Django-celery
 # -----------------------------------------------------------------------------------
-djcelery.setup_loader()
-
 BROKER_URL = 'redis://localhost:6379/%d' % (10 if TESTING else 15)
 CELERY_RESULT_BACKEND = BROKER_URL
 

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -13,7 +13,6 @@ coverage==4.0.3
 -e git+https://github.com/rapidpro/dash.git@a5d88d5817e337c486b3ac44e260e8053437b9a3#egg=dash-master
 dj-database-url==0.3.0
 django-appconf==1.0.2
-django-celery==3.1.17
 django-celery-email==1.1.4
 django-compressor==2.1
 django-contrib-comments==1.7.2

--- a/pip-requires.txt
+++ b/pip-requires.txt
@@ -4,7 +4,6 @@ celery[redis]
 colorama
 coverage
 django
-django-celery
 django-celery-email
 django-compressor
 django-debug-toolbar


### PR DESCRIPTION
And no so well maintained - doesn't have a Python 3 or Django 1.10 compatible release yet.

Need to ensure workers aren't being launched using the management command provided by django-celery, i.e. https://github.com/nyaruka/upartners/pull/2