### PR TITLE
Contact URN tweaks

### DIFF
--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -39,6 +39,7 @@ class URNTest(BaseCasesTest):
         # valid tel numbers
         self.assertEqual(URN.normalize("tel: +250788383383 "), "tel:+250788383383")
         self.assertEqual(URN.normalize("tel:+1(917)992-5253"), "tel:+19179925253")
+        self.assertEqual(URN.normalize("tel:250788383383"), "tel:+250788383383")
 
         # un-normalizable tel numbers
         self.assertEqual(URN.normalize("tel:12345"), "tel:12345")

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -51,7 +51,6 @@ class URNTest(BaseCasesTest):
         # email addresses
         self.assertEqual(URN.normalize("mailto: nAme@domAIN.cOm "), "mailto:name@domain.com")
 
-
     def test_validate(self):
         self.assertTrue(URN.validate('tel:+27825552233'))
         self.assertRaises(InvalidURN, URN.validate, 'tel:0825550011')

--- a/casepro/utils/__init__.py
+++ b/casepro/utils/__init__.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import calendar
 import iso639
 import json
-import phonenumbers
 import pytz
 import re
 import unicodedata
@@ -17,12 +16,6 @@ from uuid import UUID
 
 
 LANGUAGES_BY_CODE = {}  # cache of language lookups
-
-
-class InvalidURN(Exception):
-    """
-    A generic exception thrown when validating URNs and they don't conform to E164 format
-    """
 
 
 def parse_csv(csv, as_ints=False):
@@ -85,29 +78,6 @@ def normalize(text):
     multiple whitespace characters with single spaces.
     """
     return unicodedata.normalize('NFKD', re.sub(r'\s+', ' ', text.lower()))
-
-
-def validate_urn_as_e164(number):
-    try:
-        parsed = phonenumbers.parse(number)
-    except phonenumbers.NumberParseException as e:
-        raise InvalidURN(e.message)
-
-    if number != phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164):
-        raise InvalidURN("Phone numbers must be in E164 format")
-
-    if not phonenumbers.is_possible_number(parsed) or not phonenumbers.is_valid_number(parsed):
-        raise InvalidURN("Phone numbers must be in E164 format")
-
-    return True
-
-
-def validate_urn(urn):
-    scheme, path = urn.split(':', 1)
-    if scheme == 'tel':
-        return validate_urn_as_e164(path)
-
-    return True
 
 
 def match_keywords(text, keywords):

--- a/casepro/utils/tests.py
+++ b/casepro/utils/tests.py
@@ -16,7 +16,7 @@ from casepro.test import BaseCasesTest
 
 from . import safe_max, normalize, match_keywords, truncate, str_to_bool, json_encode, TimelineItem, uuid_to_int
 from . import date_to_milliseconds, datetime_to_microseconds, microseconds_to_datetime, month_range, date_range
-from . import get_language_name, validate_urn_as_e164, validate_urn, InvalidURN
+from . import get_language_name
 from .email import send_email
 from .middleware import JSONMiddleware
 
@@ -137,18 +137,6 @@ class UtilsTest(BaseCasesTest):
         self.assertEqual(get_language_name('arc'), "Official Aramaic")
 
         self.assertIsNone(get_language_name('xxxxx'))
-
-    def test_validate_urn_as_e164(self):
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '0825550011')  # lacks country code
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '(+27)825550011')  # incorrect format (E.123)
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '+278255500abc')  # incorrect format
-        self.assertRaises(InvalidURN, validate_urn_as_e164, '+278255500115555555')  # too long
-        self.assertTrue(validate_urn_as_e164('+27825552233'))
-
-    def test_validate_urn(self):
-        self.assertTrue(validate_urn('tel:+27825552233'))
-        self.assertRaises(InvalidURN, validate_urn, 'tel:0825550011')
-        self.assertTrue(validate_urn('unknown_scheme:address_for_unknown_scheme'))
 
 
 class EmailTest(BaseCasesTest):

--- a/karma/test-controllers.coffee
+++ b/karma/test-controllers.coffee
@@ -543,7 +543,7 @@ describe('controllers:', () ->
         redirect = spyOnPromise($q, $scope, UtilsService, 'navigate')
 
         $scope.onCaseWithoutMessage()
-        expect(ModalService.createCase).toHaveBeenCalledWith({title: 'Open case'})
+        expect(ModalService.createCase).toHaveBeenCalledWith({title: 'Open Case'})
 
         createCaseModal.resolve({text: 'test summary', partner: 2, user: 3, urn: 'tel:123'})
         expect(CaseService.open).toHaveBeenCalledWith(null, 'test summary', 2, 3, 'tel:123')
@@ -558,7 +558,7 @@ describe('controllers:', () ->
         redirect = spyOnPromise($q, $scope, UtilsService, 'navigate')
 
         $scope.onCaseWithoutMessage()
-        expect(ModalService.createCase).toHaveBeenCalledWith({title: 'Open case'})
+        expect(ModalService.createCase).toHaveBeenCalledWith({title: 'Open Case'})
 
         createCaseModal.resolve({text: 'test summary', partner: 2, user: 3, urn: 'tel:123'})
         expect(CaseService.open).toHaveBeenCalledWith(null, 'test summary', 2, 3, 'tel:123')

--- a/static/coffee/controllers.coffee
+++ b/static/coffee/controllers.coffee
@@ -71,7 +71,7 @@ controllers.controller('InboxController', ['$scope', '$window', '$location', 'La
 
   $scope.onCaseWithoutMessage = () ->
     ModalService.createCase({
-      title: "Open case"
+      title: "Open Case"
     }).then((result) ->
       CaseService.open(null, result.text, result.partner, result.user, result.urn).then((caseObj) ->
         caseUrl = 'case/read/' + caseObj.id + '/'

--- a/static/coffee/services.coffee
+++ b/static/coffee/services.coffee
@@ -612,9 +612,9 @@ services.factory('ModalService', ['$rootScope', '$uibModal', ($rootScope, $uibMo
           }
 
           $scope.refreshUserList = () ->
-              UserService.fetchInPartner($scope.fields.partner.val, true).then((users) ->
-                  $scope.fields.user.choices = [{name: "-- Anyone --"}].concat(users)
-              )
+            UserService.fetchInPartner($scope.fields.partner.val, true).then((users) ->
+              $scope.fields.user.choices = [{name: "-- Anyone --"}].concat(users)
+            )
 
           $scope.setScheme = (scheme) ->
             $scope.fields.urn.scheme = scheme
@@ -634,9 +634,9 @@ services.factory('ModalService', ['$rootScope', '$uibModal', ($rootScope, $uibMo
           $scope.setScheme('tel')
 
           PartnerService.fetchAll().then((partners) ->
-              $scope.fields.partner.choices = partners
-              $scope.fields.partner.val = partners[0]
-              $scope.refreshUserList()
+            $scope.fields.partner.choices = partners
+            $scope.fields.partner.val = partners[0]
+            $scope.refreshUserList()
           )
       })
       .result

--- a/static/templates/modals/create_case.html
+++ b/static/templates/modals/create_case.html
@@ -29,15 +29,15 @@
                 Invalid phone number format. Should be in the format +27741234567
             </div>
         </div>
-        <div class="form-group" ng-class='{"has-error": form.text.$invalid}'>
+        <div class="form-group" ng-class='{"has-error": form.text.$invalid && form.submitted}'>
             <label class="control-label">
                 Summary
             </label>
             <textarea class="form-control" ng-model="fields.text.val" ng-maxlength="fields.text.maxLength" name="text" required></textarea>
-            <div class="help-block" ng-show="form.text.$error.required">
+            <div class="help-block" ng-show="form.text.$error.required && form.submitted">
                 Required
             </div>
-            <div class="help-block" ng-show="form.text.$error.maxlength">
+            <div class="help-block" ng-show="form.text.$error.maxlength && form.submitted">
                 Too long
             </div>
         </div>


### PR DESCRIPTION
* Moves URN functionality into URN class
* Add support for normalizing URNs
* Fixes open case modal so required error not shown on Summary field unless form has been submitted

@KaitCrawford currently on the 'Open Case' modal, the user has to type a phone number in exactly E164 format, and sees an error message as they type. This PR doesn't address that but does add normalization on the server side, so it might be possible to relax that restriction and let users type things like "260 96-123-1234"