### PR TITLE
Tweaks to contact displaying

### DIFF
--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -261,6 +261,10 @@ class Contact(models.Model):
     """
     A contact in RapidPro
     """
+    DISPLAY_NAME = 'name'
+    DISPLAY_URNS = 'urns'
+    DISPLAY_ANON = 'uuid'
+
     SAVE_GROUPS_ATTR = '__data__groups'
 
     org = models.ForeignKey(Org, verbose_name=_("Organization"), related_name="contacts")
@@ -336,14 +340,14 @@ class Contact(models.Model):
         If the display setting is recognised and set then that field is returned, otherwise the name is returned.
         If no name is set an empty string is returned.
         """
-        display_format = getattr(settings, 'SITE_CONTACT_DISPLAY', 'name')
+        display_format = getattr(settings, 'SITE_CONTACT_DISPLAY', self.DISPLAY_NAME)
 
-        if display_format == "uuid" and self.uuid:
+        if display_format == self.DISPLAY_ANON and self.uuid:
             return self.uuid[:6].upper()
-        elif display_format == "urns" and self.urns:
+        elif display_format == self.DISPLAY_URNS and self.urns:
             _scheme, path = URN.to_parts(self.urns[0])
             return path
-        elif display_format == "name" and self.name:
+        elif display_format == self.DISPLAY_NAME and self.name:
             return self.name
 
         return "---"

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -118,28 +118,21 @@ class ContactTest(BaseCasesTest):
 
         self.assertEqual(set(contact.groups.all()), {spammers, boffins})
 
-    def test_get_display_name(self):
-        # if site uses anon contacts then obscure this
-        with override_settings(SITE_ANON_CONTACTS=True):
-            self.assertEqual(self.ann.get_display_name(), "7B7DD8")
-            self.ann.uuid = None
-            self.assertEqual(self.ann.get_display_name(), "")
-        self.ann.refresh_from_db()
-
+    def test_get_display(self):
         # if the site uses 'uuid' for the display
         with override_settings(SITE_CONTACT_DISPLAY="uuid"):
-            self.assertEqual(self.ann.get_display_name(), "7B7DD8")
+            self.assertEqual(self.ann.get_display(), "7B7DD8")
 
         # if the site uses 'urns' for the display
         self.ann.urns = ['tel:+2345']
         with override_settings(SITE_CONTACT_DISPLAY="urns"):
-            self.assertEqual(self.ann.get_display_name(), "+2345")
+            self.assertEqual(self.ann.get_display(), "+2345")
         self.ann.refresh_from_db()
 
         # if the site uses 'name' or something unrecognised for the display
-        self.assertEqual(self.ann.get_display_name(), "Ann")
+        self.assertEqual(self.ann.get_display(), "Ann")
         self.ann.name = None
-        self.assertEqual(self.ann.get_display_name(), "")
+        self.assertEqual(self.ann.get_display(), "---")
 
     def test_get_fields(self):
         self.assertEqual(self.ann.get_fields(), {'age': "32", 'state': "WA"})  # what is stored on the contact

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -54,7 +54,7 @@ SITE_ORGS_STORAGE_ROOT = 'orgs'
 SITE_EXTERNAL_CONTACT_URL = 'http://localhost:8001/contact/read/%s/'
 SITE_BACKEND = 'casepro.backend.NoopBackend'
 SITE_HIDE_CONTACT_FIELDS = []  # Listed fields should not be displayed
-SITE_CONTACT_DISPLAY = "name"  # Overrules SITE_HIDE_CONTACT_FIELDS Options: 'name', 'uuid' or 'urn'
+SITE_CONTACT_DISPLAY = "name"  # Overrules SITE_HIDE_CONTACT_FIELDS Options: 'name', 'uuid' or 'urns'
 SITE_ALLOW_CASE_WITHOUT_MESSAGE = True
 
 # junebug configuration


### PR DESCRIPTION
* Rename `Contact.get_display_name` to `Contact.get_display` for clarity
* Remove support for `SITE_ANON_CONTACTS` which has been replaced by `SITE_HIDE_CONTACT_FIELDS`
* Use placeholder (---) when there's nothing to display for a contact