### PR TITLE
Disable exception reporting for DisallowedHost

### DIFF
--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -223,7 +223,10 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
-        }
+        },
+        'null': {
+            'class': 'logging.NullHandler',
+        },
     },
     'loggers': {
         'httprouterthread': {
@@ -237,6 +240,10 @@ LOGGING = {
         'django.db.backends': {
             'level': 'ERROR',
             'handlers': ['console'],
+            'propagate': False,
+        },
+        'django.security.DisallowedHost': {
+            'handlers': ['null'],
             'propagate': False,
         },
     }


### PR DESCRIPTION
We're getting a lot of these in Sentry but there's not much to be done about them, and this is how the Django docs recommend disabling the exceptions.