### PR TITLE
FAQ fixes and UI tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,9 @@ var/
 *.egg
 
 # Exclude media folder except files used for import testing
-media/test_orgs
-media/csv_imports
+media
+!media/test_orgs
+!media/csv_imports
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/casepro/profiles/context_processors.py
+++ b/casepro/profiles/context_processors.py
@@ -8,11 +8,14 @@ def user(request):
     if request.user.is_anonymous() or not request.org:
         is_admin = False
         partner = None
+        is_faq_only = True
     else:
         is_admin = request.user.can_administer(request.org)
         partner = request.user.get_partner(request.org)
+        is_faq_only = request.user.must_use_faq()
 
     return {
         'user_is_admin': is_admin,
-        'user_partner': partner
+        'user_partner': partner,
+        'user_is_faq_only': is_faq_only
     }

--- a/static/coffee/modals.coffee
+++ b/static/coffee/modals.coffee
@@ -63,12 +63,13 @@ modals.controller('ReplyModalController', ['$scope', 'FaqService', '$uibModalIns
   $scope.fields = {text: {val: '', maxLength: maxLength}}
   $scope.sendToMany = if selection then true else false
 
-  $scope.init = () ->
+  $scope.init = (faqOnly) ->
     $scope.searchField = $scope.searchFieldDefaults()
     $scope.search = $scope.buildSearch()
     $scope.fetchFaqs()
     $scope.fetchLanguages()
     $scope.lang = "Select language"
+    $scope.faqOnly = faqOnly
 
   $scope.buildSearch = () ->
     search = angular.copy($scope.searchField)

--- a/static/less/cases.less
+++ b/static/less/cases.less
@@ -39,19 +39,21 @@
 }
 
 .content {
-  border-radius: 0px;
+  border-radius: 0;
 }
 
 .no-margin {
   margin: 0;
 }
 
-.no-bottom-padding {
-  padding-bottom: 0;
-}
-
 .no-border {
   border: 0;
+}
+
+.search-toolbar {
+  padding: 7px;
+  background-color: #f7f7f7;
+  margin-top: 7px;
 }
 
 footer {
@@ -74,10 +76,6 @@ footer {
   }
 }
 
-.glyphicon-duplicate:before {
-  content: "\e224";
-}
-
 tr + .emptymessage {
     display: none;
 }
@@ -90,8 +88,8 @@ tr + .emptymessage {
 }
 
 .input-clear .glyphicon {
-      pointer-events: all;
-    }
+  pointer-events: all;
+}
 
 /**
  * Smartmin tweaks - consistent layout for read page tables
@@ -228,12 +226,4 @@ td.value-question {
 .field-test-widget .control-label {
   display: inline-block;
   padding: 5px 0;
-}
-
-.list-group-item {
-  padding: 5px 12px;
-  word-wrap: break-word;
-}
-.modal-body .well {
-  margin-bottom: 10px;
 }

--- a/templates/cases/partner_read.haml
+++ b/templates/cases/partner_read.haml
@@ -211,11 +211,6 @@
     .partner-label {
       margin-left: 1em
     }
-    .search-toolbar {
-      padding: 7px;
-      background-color: #f7f7f7;
-      margin-top: 7px;
-    }
     .search-toolbar .date-range .input-group, .date-range label {
       float: left;
     }

--- a/templates/msgs/faq_list.haml
+++ b/templates/msgs/faq_list.haml
@@ -9,17 +9,17 @@
     .clearfix
       .page-header-buttons
         .btn-group
-          %a.btn.btn-default{ href:"{% url 'msgs.faq_import' %}" }
-            %span.glyphicon.glyphicon-duplicate
-            - trans "Batch Upload"
-          %a.btn.btn-default{ ng-click:"onNewFaq(faq)", tooltip:"New FAQ" }
+          %a.btn.btn-default{ ng-click:"onNewFaq(faq)", tooltip:"Add new FAQ" }
             %span.glyphicon.glyphicon-plus
             - trans "Add"
+          %a.btn.btn-default{ href:"{% url 'msgs.faq_import' %}" }
+            %span.glyphicon.glyphicon-import
+            - trans "Import"
       .page-header
         %h2
           - trans "FAQs"
       
-      %table.table.table-striped.list-table.table-bordered
+      %table.table.table-striped.list-table
         %thead
           %tr
             %th
@@ -32,18 +32,17 @@
               - trans "Translations"
 
         %tbody
-          
-            %tr{ ng-repeat:"faq in faqs | filter:filterParents" }
-              %td
-                %a{ ng-href:"/faq/read/[[ faq.id ]]/" }
-                  [[ faq.question ]]
-              %td.col-xs-6
-                [[ faq.answer ]]
-              %td
-                [[ faq.language.name ]]
-              %td.text-center
-                %span.badge
-                  [[ faq.count ]]
+          %tr{ ng-repeat:"faq in faqs | filter:filterParents" }
+            %td
+              %a{ ng-href:"/faq/read/[[ faq.id ]]/" }
+                [[ faq.question ]]
+            %td.col-xs-6
+              [[ faq.answer ]]
+            %td
+              [[ faq.language.name ]]
+            %td.text-center
+              %span.badge
+                [[ faq.count ]]
             
 - block pjax
 

--- a/templates/msgs/faq_read.haml
+++ b/templates/msgs/faq_read.haml
@@ -18,35 +18,30 @@
                 %i.glyphicon.glyphicon-trash
 
       %h2
-        FAQ Details
+        FAQ: [[ faq.question ]]
+
     %table.table.table-striped
       %tbody
-          %tr
-            %td.read-label
-              - trans "Question"
-            %td.read-value
-              %span
-              [[ faq.question ]]
-          %tr
-            %td.read-label
-              - trans "Answer"
-            %td.read-value
-              %span
-                [[ faq.answer ]]
-          %tr
-            %td.read-label
-              - trans "Language"
-            %td.read-value
-              %spans 
-              [[ faq.language.name ]]
-          %tr
-            %td.read-label
-              - trans "Labels"
-            %td.read-value
-              %span{ ng-repeat:'label in faq.labels' }
-                %span.label.label-success
-                  [[ label.name ]]
-                &nbsp;
+        %tr
+          %td.read-label
+            - trans "Answer"
+          %td.read-value
+            %span
+              [[ faq.answer ]]
+        %tr
+          %td.read-label
+            - trans "Language"
+          %td.read-value
+            %spans
+            [[ faq.language.name ]]
+        %tr
+          %td.read-label
+            - trans "Labels"
+          %td.read-value
+            %span{ ng-repeat:'label in faq.labels' }
+              %span.label.label-success
+                [[ label.name ]]
+              &nbsp;
         
             
     .page-header.clearfix
@@ -57,7 +52,7 @@
               %span.glyphicon.glyphicon-plus
               - trans "Add Translation"
 
-      %h2
+      %h3
         Translations
     
     %table.table.table-striped
@@ -70,28 +65,24 @@
           %th.col-xs-4
             - trans "Answer"
           %th
-            - trans "Edit"
-          %th
-            - trans "Delete"
 
       %tbody
-          %tr.translation{ ng-repeat:"translation in translations | filter:filterTranslations(faq.id)" }
-            %td
-              [[ translation.language.name ]]
-            %td
-              [[ translation.question ]]
-            %td
-              [[ translation.answer ]]
-            %td
+        %tr.translation{ ng-repeat:"translation in translations | filter:filterTranslations(faq.id)" }
+          %td
+            [[ translation.language.name ]]
+          %td
+            [[ translation.question ]]
+          %td
+            [[ translation.answer ]]
+          %td{ style:"text-align: right" }
+            .btn-group
               %a.btn.btn-default{ ng-click:"onEditTranslation(translation, faq)", tooltip:"Edit Translation" }
                 %i.glyphicon.glyphicon-pencil
-            %td
               %a.btn.btn-default{ ng-click:"onDeleteFaqTranslation(translation)", tooltip:"Delete Translation" }
                 %i.glyphicon.glyphicon-trash
-          %tr.emptymessage
-            %td
-              - trans "No translations available"  
-
+        %tr.emptymessage
+          %td
+            - trans "No translations available"
 
 
 - block read-buttons

--- a/templates/partials/modal_reply.haml
+++ b/templates/partials/modal_reply.haml
@@ -4,17 +4,21 @@
   %h3.modal-title
     - trans "Reply"
 
-.modal-body{ ng-init:'init()' }
+.modal-body{ ng-init:'init({{ user_is_faq_only|yesno:"true,false" }})' }
   %p{ ng-if:'sendToMany' }
     - trans "Send the following reply to the selected message(s). This will remove the message(s) from your inbox to Archived."
   %p{ ng-if:'!sendToMany' }
     - trans "Send the following reply. This will archive this message removing it from your Inbox."
 
+  %p{ ng-if:'faqOnly && replies.length > 0' }
+    - trans "Please select one of the following FAQ replies."
+  .alert.alert-danger{ ng-if:'faqOnly && replies.length == 0' }
+    - trans "There are no pre-approved replies. Please contact your administrator."
+  %p{ ng-if:'!faqOnly && replies.length > 0' }
+    - trans "You may select one of the following FAQ replies or enter a custom message below."
+
   %form{ name:"form", novalidate:"" }
     .form-group{ ng-if:"replies.length > 0" }
-      %label.control-label
-        -trans "Select Response"
-
       .search-toolbar.clearfix
         .pull-back
           %input.form-control{ type:"text", placeholder:'Label or keyword', ng-model:'searchFaqs', style:"width: 250px" }
@@ -38,7 +42,7 @@
             %b[[reply.question]]
             %p.no-margin[[reply.answer]]
 
-    - if user_must_reply_with_faq
+    - if user_is_faq_only
       .form-group
         %textarea.form-control{ ng-model:"fields.text.val", ng-maxlength:"fields.text.maxLength", name:"text", required:"", readonly:"" }
     - else

--- a/templates/partials/modal_reply.haml
+++ b/templates/partials/modal_reply.haml
@@ -3,53 +3,51 @@
 .modal-header.no-border
   %h3.modal-title
     - trans "Reply"
-  .modal-body.no-bottom-padding{ ng-init:'init()' }
-    %p{ ng-if:'sendToMany' }
-      - trans "Send the following reply to the selected message(s). This will remove the message(s) from your inbox to Archived."
-    %p{ ng-if:'!sendToMany' }
-      - trans "Send the following reply. This will archive this message removing it from your Inbox."
-    %form{ name:"form", novalidate:"" }
-      .form-group{ ng-class:'{"has-error": form.text.$invalid && (form.text.$dirty || form.submitted)}' }
+
+.modal-body{ ng-init:'init()' }
+  %p{ ng-if:'sendToMany' }
+    - trans "Send the following reply to the selected message(s). This will remove the message(s) from your inbox to Archived."
+  %p{ ng-if:'!sendToMany' }
+    - trans "Send the following reply. This will archive this message removing it from your Inbox."
+
+  %form{ name:"form", novalidate:"" }
+    .form-group{ ng-if:"replies.length > 0" }
+      %label.control-label
+        -trans "Select Response"
+
+      .search-toolbar.clearfix
+        .pull-back
+          %input.form-control{ type:"text", placeholder:'Label or keyword', ng-model:'searchFaqs', style:"width: 250px" }
+        .pull-away
+          .btn-group{ uib-dropdown:"true" }
+            %button.btn.btn-default.dropdown-toggle{ type:"button", uib-dropdown-toggle:"true" }
+              [[lang]]
+              %span.caret
+            %ul.dropdown-menu
+              %li{ ng-repeat:'language in languages' }
+                %a{ ng-click:"filterByLanguage(language)" }
+                  [[language.name]]
+
+      .{ style:"overflow-y:scroll; max-height:12em;" }
+        .stackitem.clearfix.hoverable{ ng-repeat:"reply in replies | filter:searchFaqs", ng-click:"setResponse(reply.answer)" }
+          .small
+            %span.label-container{ ng-repeat:"label in reply.labels" }
+              %span.label.label-success
+                [[ label.name ]]
+              &nbsp;
+            %b[[reply.question]]
+            %p.no-margin[[reply.answer]]
+
+    - if user_must_reply_with_faq
       .form-group
-        .well.well-small.col-md-12
-          .row
-            .col-md-8.col-xs-8
-              %input.form-control{ type:"text", placeholder:'Search Label or Keyword',ng-model:'searchFaqs' }
-            .col-md-4.col-xs-4
-              .btn-group{ uib-dropdown:"true" }
-                %button.btn.btn-default.dropdown-toggle{ type:"button", uib-dropdown-toggle:"true" }
-                  [[lang]]
-                  %span.caret
-                %ul.dropdown-menu
-                  %li{ng-repeat:'language in languages'}
-                    %a{ ng-click:"filterByLanguage(language)" }
-                      [[language.name]]
-      %small
-        %label.control-label
-            -trans "Select a Response"
-      .form-group
-        %ul.list-group.col-md-12.col-xs-12{style:'overflow-x:auto;max-height:40vh;'}
-          %li.list-group-item{ng-repeat:"reply in replies | filter:searchFaqs"}
-            %span.small{ng-click:"setResponse(reply.answer)"}
-              %span.label-container{ ng-repeat:"label in reply.labels" }
-                %span.label.label-success
-                  [[ label.name ]]
-                &nbsp;
-              %b[[reply.question]]
-              %p.no-margin[[reply.answer]]
-
-      - if user_must_reply_with_faq
-        .form-group
-          %textarea.form-control{ ng-model:"fields.text.val", ng-maxlength:"fields.text.maxLength", name:"text", required:"", readonly:"" }
-      - else
-        .form-group.no-margin{ ng-class:'{"has-error": form.text.$invalid && (form.text.$dirty || form.submitted)}' }
-          %textarea.form-control{ ng-model:"fields.text.val", ng-maxlength:"fields.text.maxLength", name:"text", required:"", placeholder:'Enter a custom message' }
-            .help-block{ ng-show:"form.text.$error.required && (form.text.$dirty || form.submitted)" }
-              - trans "Required"
-            .help-block{ ng-show:"form.text.$error.maxlength" }
-              - trans "Too long"
-
-
+        %textarea.form-control{ ng-model:"fields.text.val", ng-maxlength:"fields.text.maxLength", name:"text", required:"", readonly:"" }
+    - else
+      .form-group.no-margin{ ng-class:'{"has-error": form.text.$invalid && (form.text.$dirty || form.submitted)}' }
+        %textarea.form-control{ ng-model:"fields.text.val", ng-maxlength:"fields.text.maxLength", name:"text", required:"", placeholder:'Enter a custom message' }
+          .help-block{ ng-show:"form.text.$error.required && (form.text.$dirty || form.submitted)" }
+            - trans "Required"
+          .help-block{ ng-show:"form.text.$error.maxlength" }
+            - trans "Too long"
 
 .modal-footer
   %button.btn.btn-primary{ ng-click:"ok()" }

--- a/templates/partials/modal_reply.haml
+++ b/templates/partials/modal_reply.haml
@@ -11,11 +11,11 @@
     - trans "Send the following reply. This will archive this message removing it from your Inbox."
 
   %p{ ng-if:'faqOnly && replies.length > 0' }
-    - trans "Please select one of the following FAQ replies."
+    - trans "Please select one of the following pre-approved replies."
   .alert.alert-danger{ ng-if:'faqOnly && replies.length == 0' }
     - trans "There are no pre-approved replies. Please contact your administrator."
   %p{ ng-if:'!faqOnly && replies.length > 0' }
-    - trans "You may select one of the following FAQ replies or enter a custom message below."
+    - trans "You may select one of the following pre-approved replies or enter a custom message below."
 
   %form{ name:"form", novalidate:"" }
     .form-group{ ng-if:"replies.length > 0" }


### PR DESCRIPTION
* Makes styling more consistent with rest of app
* Fixes bug where reply modal isn't affected by whether user must use FAQs #199 
* Improves instructions on reply modal based on what user can do

Before:
<img width="770" alt="screen shot 2016-11-18 at 11 00 10" src="https://cloud.githubusercontent.com/assets/675558/20424511/f060dd8a-ad7e-11e6-9a09-463ccb04419c.png">

After:
<img width="772" alt="screen shot 2016-11-18 at 11 01 09" src="https://cloud.githubusercontent.com/assets/675558/20424515/f6180636-ad7e-11e6-913b-0d827ad0d536.png">

Before:
<img width="772" alt="screen shot 2016-11-18 at 11 00 21" src="https://cloud.githubusercontent.com/assets/675558/20424524/0a175272-ad7f-11e6-8d80-fc65d6749aaa.png">

After:
<img width="770" alt="screen shot 2016-11-18 at 11 00 52" src="https://cloud.githubusercontent.com/assets/675558/20424530/0d315b38-ad7f-11e6-950e-0de7dd32b28e.png">

Before:
<img width="608" alt="screen shot 2016-11-18 at 10 59 43" src="https://cloud.githubusercontent.com/assets/675558/20424537/18b0b792-ad7f-11e6-8a9e-a1887ea2bae8.png">

After (when user isn't limited to FAQs and there are some):
<img width="609" alt="screen shot 2016-11-18 at 11 12 26" src="https://cloud.githubusercontent.com/assets/675558/20424739/1aab36f2-ad80-11e6-90f8-5507ee0995cf.png">

After (when user isn't limited to FAQs and there aren't any):
<img width="612" alt="screen shot 2016-11-18 at 10 56 07" src="https://cloud.githubusercontent.com/assets/675558/20424558/34c3a46c-ad7f-11e6-867c-1e74db53f816.png">

After (when user is limited to FAQs and there are some):
<img width="609" alt="screen shot 2016-11-18 at 11 13 01" src="https://cloud.githubusercontent.com/assets/675558/20424759/3611daf4-ad80-11e6-8c00-3d495e7a8311.png">

After (when user is limited to FAQs and there aren't any):
<img width="613" alt="screen shot 2016-11-18 at 10 55 34" src="https://cloud.githubusercontent.com/assets/675558/20424588/606ea3aa-ad7f-11e6-9cfb-012c97e03e5d.png">
