### PR TITLE
Fix urn contact display

### DIFF
--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -495,6 +495,7 @@ class BaseInboxView(OrgPermsMixin, SmartTemplateView):
         context['open_case_count'] = Case.get_open(org, user).count()
         context['closed_case_count'] = Case.get_closed(org, user).count()
         context['allow_case_without_message'] = getattr(settings, 'SITE_ALLOW_CASE_WITHOUT_MESSAGE', False)
+        context['site_contact_display'] = getattr(settings, 'SITE_CONTACT_DISPLAY', "name")
         return context
 
 

--- a/templates/cases/inbox_messages.haml
+++ b/templates/cases/inbox_messages.haml
@@ -217,6 +217,7 @@
     .message-text {
       word-wrap: break-word;
       overflow-wrap: break-word;
+      overflow: hidden;
     }
     .message-actions .flag {
       color: #ddd;

--- a/templates/cases/inbox_messages.haml
+++ b/templates/cases/inbox_messages.haml
@@ -202,7 +202,7 @@
     }
     .message-contact {
       float: left;
-      width: 80px;
+      width: 120px;
     }
     .message-actions input[type="checkbox"] {
       width: auto;
@@ -215,7 +215,7 @@
       margin-bottom: 3px;
     }
     .message-text {
-      margin-left: 130px;
+      margin-left: 170px;
       word-wrap: break-word;
       overflow-wrap: break-word;
     }

--- a/templates/cases/inbox_messages.haml
+++ b/templates/cases/inbox_messages.haml
@@ -138,8 +138,14 @@
         .message-time
           <cp-date time="item.time" />
         .message-contact
-          %a{ ng-click:"activateContact(item.contact)" }><
-            <cp-contact contact="item.contact" fields="fields">
+          -if site_contact_display == "urns"
+            .message-contact-urns
+              %a{ ng-click:"activateContact(item.contact)" }><
+                <cp-contact contact="item.contact" fields="fields">
+          -else
+            .message-contact-default
+              %a{ ng-click:"activateContact(item.contact)" }><
+                <cp-contact contact="item.contact" fields="fields">
         .message-text
           %span.label-container{ ng-if:"item.flow" }
             %span.label.label-info
@@ -200,9 +206,13 @@
       float: left;
       width: 50px;
     }
-    .message-contact {
+    .message-contact-default {
       float: left;
-      margin-right: 10px;
+      width: 80px;
+    }
+    .message-contact-urns {
+      float: left;
+      width: 130px;
     }
     .message-actions input[type="checkbox"] {
       width: auto;

--- a/templates/cases/inbox_messages.haml
+++ b/templates/cases/inbox_messages.haml
@@ -137,15 +137,9 @@
             %i.glyphicon.glyphicon-flag
         .message-time
           <cp-date time="item.time" />
-        .message-contact
-          -if site_contact_display == "urns"
-            .message-contact-urns
-              %a{ ng-click:"activateContact(item.contact)" }><
-                <cp-contact contact="item.contact" fields="fields">
-          -else
-            .message-contact-default
-              %a{ ng-click:"activateContact(item.contact)" }><
-                <cp-contact contact="item.contact" fields="fields">
+        .{ class:"{% if site_contact_display == 'urns' %}message-contact-urns{% else %}message-contact-default{% endif %}" }
+          %a{ ng-click:"activateContact(item.contact)" }><
+            <cp-contact contact="item.contact" fields="fields">
         .message-text
           %span.label-container{ ng-if:"item.flow" }
             %span.label.label-info

--- a/templates/cases/inbox_messages.haml
+++ b/templates/cases/inbox_messages.haml
@@ -202,7 +202,7 @@
     }
     .message-contact {
       float: left;
-      width: 120px;
+      margin-right: 10px;
     }
     .message-actions input[type="checkbox"] {
       width: auto;
@@ -215,7 +215,6 @@
       margin-bottom: 3px;
     }
     .message-text {
-      margin-left: 170px;
       word-wrap: break-word;
       overflow-wrap: break-word;
     }


### PR DESCRIPTION
Urns displayed on the inbox page are displaying poorly due to a lack of space.
This adjusts the css based on the SITE_CONTACT_DISPLAY setting
Before changes:
![urns display](https://cloud.githubusercontent.com/assets/1230707/20711872/7515f7c6-b64a-11e6-8733-2ea0f1b9d12e.png)
After changes:
![contact_display_fix](https://cloud.githubusercontent.com/assets/1230707/20711903/999f1bae-b64a-11e6-85a6-34dd0cf66322.png)
