### PR TITLE
👷 Actions should still succeed even if their backend operations fail

### DIFF
--- a/casepro/rules/models.py
+++ b/casepro/rules/models.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from enum import Enum
 
 import regex
+from celery.utils.log import get_task_logger
 from dash.orgs.models import Org
 from dash.utils import get_obj_cacheable
 from django.db import models
@@ -14,6 +15,8 @@ from casepro.msgs.models import Label, Message
 from casepro.utils import json_encode, normalize
 
 KEYWORD_REGEX = regex.compile(r"^\w[\w\- ]*\w$", flags=regex.UNICODE | regex.V0)
+
+logger = get_task_logger(__name__)
 
 
 class Quantifier(Enum):
@@ -330,7 +333,10 @@ class LabelAction(Action):
             msg.label(self.label)
 
         if self.label.is_synced:
-            org.get_backend().label_messages(org, messages, self.label)
+            try:
+                org.get_backend().label_messages(org, messages, self.label)
+            except Exception as e:
+                logger.exception(e)
 
     def __eq__(self, other):
         return self.TYPE == other.TYPE and self.label == other.label
@@ -359,7 +365,10 @@ class FlagAction(Action):
     def apply_to(self, org, messages):
         Message.objects.filter(pk__in=[m.pk for m in messages]).update(is_flagged=True)
 
-        org.get_backend().flag_messages(org, messages)
+        try:
+            org.get_backend().flag_messages(org, messages)
+        except Exception as e:
+            logger.exception(e)
 
 
 class ArchiveAction(Action):
@@ -382,7 +391,10 @@ class ArchiveAction(Action):
     def apply_to(self, org, messages):
         Message.objects.filter(pk__in=[m.pk for m in messages]).update(is_archived=True)
 
-        org.get_backend().archive_messages(org, messages)
+        try:
+            org.get_backend().archive_messages(org, messages)
+        except Exception as e:
+            logger.exception(e)
 
 
 class Rule(models.Model):

--- a/casepro/rules/tests.py
+++ b/casepro/rules/tests.py
@@ -154,6 +154,15 @@ class ActionsTest(BaseCasesTest):
 
         self.assertEqual(set(msg.labels.all()), {self.aids})
 
+        # check that action completes even if backend errors
+        with patch("casepro.test.TestBackend.label_messages") as mock_label:
+            mock_label.side_effect = ValueError("DOH")
+
+            msg = self.create_message(self.unicef, 103, self.ann, "green")
+            action.apply_to(self.unicef, [msg])
+
+            self.assertEqual(set(msg.labels.all()), {self.aids})
+
     def test_flag(self):
         action = Action.from_json({"type": "flag"}, self.context)
         self.assertEqual(action.TYPE, "flag")
@@ -169,6 +178,16 @@ class ActionsTest(BaseCasesTest):
         msg.refresh_from_db()
         self.assertTrue(msg.is_flagged)
 
+        # check that action completes even if backend errors
+        with patch("casepro.test.TestBackend.flag_messages") as mock_flag:
+            mock_flag.side_effect = ValueError("DOH")
+
+            msg = self.create_message(self.unicef, 103, self.ann, "green")
+            action.apply_to(self.unicef, [msg])
+
+            msg.refresh_from_db()
+            self.assertTrue(msg.is_flagged)
+
     def test_archive(self):
         action = Action.from_json({"type": "archive"}, self.context)
         self.assertEqual(action.TYPE, "archive")
@@ -183,6 +202,16 @@ class ActionsTest(BaseCasesTest):
 
         msg.refresh_from_db()
         self.assertTrue(msg.is_archived)
+
+        # check that action completes even if backend errors
+        with patch("casepro.test.TestBackend.archive_messages") as mock_archive:
+            mock_archive.side_effect = ValueError("DOH")
+
+            msg = self.create_message(self.unicef, 103, self.ann, "green")
+            action.apply_to(self.unicef, [msg])
+
+            msg.refresh_from_db()
+            self.assertTrue(msg.is_archived)
 
 
 class RuleTest(BaseCasesTest):


### PR DESCRIPTION
log that to sentry