### PR TITLE
Render label rule tests on read page

### DIFF
--- a/casepro/cases/management/commands/test_db.py
+++ b/casepro/cases/management/commands/test_db.py
@@ -1,6 +1,7 @@
 import math
 import random
 import time
+from uuid import uuid4
 
 import pytz
 from dash.orgs.models import Org
@@ -11,7 +12,7 @@ from django.core.management import BaseCommand, CommandError
 from django.utils import timezone
 
 from casepro.cases.models import Partner
-from casepro.contacts.models import Contact
+from casepro.contacts.models import Contact, Field, Group
 from casepro.msgs.models import Label, Labelling, Message
 from casepro.profiles.models import ROLE_ANALYST, ROLE_MANAGER, Profile
 from casepro.rules.models import ContainsTest, Quantifier
@@ -22,7 +23,11 @@ from casepro.statistics.tasks import squash_counts
 USER_PASSWORD = "Qwerty123"
 
 # create 10 orgs with these names
-ORG_NAMES = ("Ecuador", "Rwanda", "Croatia", "USA", "Mexico", "Zambia", "India", "Brazil", "Sudan", "Mozambique")
+ORGS = ("Ecuador", "Rwanda", "Croatia", "USA", "Mexico", "Zambia", "India", "Brazil", "Sudan", "Mozambique")
+
+GROUPS = ("U-Reporters", "Youth", "Male", "Female")
+
+FIELDS = ({"label": "Gender", "key": "gender", "value_type": "T"}, {"label": "Age", "key": "age", "value_type": "N"})
 
 # each org will have these partner orgs
 PARTNERS = (
@@ -56,7 +61,7 @@ MESSAGE_WORDS = ("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipi
 # We want a variety of large and small orgs so when allocating messages, we apply a bias toward the beginning
 # orgs. if there are N orgs, then the amount of content the first org will be allocated is (1/N) ^ (1/bias).
 # This sets the bias so that the first org will get ~50% of the content:
-BIASED = math.log(1.0 / len(ORG_NAMES), 0.5)
+BIASED = math.log(1.0 / len(ORGS), 0.5)
 
 
 class Command(BaseCommand):
@@ -99,12 +104,12 @@ class Command(BaseCommand):
 
         superuser = User.objects.create_superuser("root", "root@nyaruka.com", USER_PASSWORD)
 
-        orgs = self.create_orgs(superuser, ORG_NAMES, PARTNERS, USER_PASSWORD)
+        orgs = self.create_orgs(superuser, ORGS, GROUPS, FIELDS, PARTNERS, USER_PASSWORD)
         self.create_contacts(orgs, 100)
 
         return orgs
 
-    def create_orgs(self, superuser, org_names, partner_specs, password):
+    def create_orgs(self, superuser, org_names, group_names, field_specs, partner_specs, password):
         """
         Creates the orgs
         """
@@ -126,6 +131,14 @@ class Command(BaseCommand):
             Profile.create_org_user(
                 org, "Adam", f"admin{o+1}@unicef.org", password, change_password=False, must_use_faq=False
             )
+
+            for group_name in group_names:
+                Group.objects.create(org=org, uuid=str(uuid4()), name=group_name)
+
+            for field_spec in field_specs:
+                Field.objects.create(
+                    org=org, label=field_spec["label"], key=field_spec["key"], value_type=field_spec["value_type"]
+                )
 
             label_names = set()
             for partner_spec in partner_specs:

--- a/casepro/msgs/views.py
+++ b/casepro/msgs/views.py
@@ -118,6 +118,9 @@ class LabelCRUDL(SmartCRUDL):
 
             # angular app requires context data in JSON format
             context["context_data_json"] = json_encode({"label": label_json})
+
+            context["rule_tests"] = self.object.rule.get_tests_description() if self.object.rule else ""
+
             return context
 
     class Delete(OrgObjPermsMixin, SmartDeleteView):

--- a/casepro/rules/templatetags/rules.py
+++ b/casepro/rules/templatetags/rules.py
@@ -1,0 +1,50 @@
+from django import template
+from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext_lazy as _
+
+from casepro.rules.models import ContainsTest, FieldTest, GroupsTest, WordCountTest
+
+register = template.Library()
+
+
+def render_contains_test(test):
+    if len(test.keywords) > 1:
+        contains = f"{str(test.quantifier)} " + ", ".join([f'<i>"{w}"</i>' for w in test.keywords])
+    else:
+        contains = f'<i>"{test.keywords[0]}"</i>'
+    return f"message contains {contains}"
+
+
+def render_groups_test(test):
+    if len(test.groups) > 1:
+        membership = f"{str(test.quantifier)} " + ", ".join([f"<i>{g}</i>" for g in test.groups])
+    else:
+        membership = f"<i>{test.groups[0]}</i>"
+
+    return f"contact belongs to {membership}"
+
+
+def render_field_test(test):
+    return f"contact <i>{test.key}</i> is equal to <i>{test.values[0]}</i>"
+
+
+def render_word_count_test(test):
+    return f"message has at least {test.minimum} words"
+
+
+TEST_RENDERERS = {
+    ContainsTest: render_contains_test,
+    GroupsTest: render_groups_test,
+    FieldTest: render_field_test,
+    WordCountTest: render_word_count_test,
+}
+
+
+@register.filter
+def render_tests(rule):
+    rendered_tests = []
+    for test in rule.get_tests():
+        renderer = TEST_RENDERERS[type(test)]
+        rendered_tests.append(renderer(test))
+
+    return mark_safe(_(", and ").join(rendered_tests))

--- a/templates/msgs/label_read.haml
+++ b/templates/msgs/label_read.haml
@@ -1,29 +1,29 @@
 - extends "smartmin/read.html"
-- load smartmin i18n thumbnail
+- load smartmin i18n thumbnail rules
 
 - block pre-content
 
 - block content
 
-  %script{ type:"text/javascript" }
+  %script(type="text/javascript")
     var contextData = {{ context_data_json|safe }};
 
-  .ng-cloak{ ng-controller:"LabelController", ng-init:"init()", ng-cloak:"" }
-    .page-header.clearfix{ style:"border-bottom: none" }
-      .clearfix{ style:"margin-bottom: 10px" }
+  .ng-cloak(ng-controller="LabelController" ng-init="init()" ng-cloak="")
+    .page-header.clearfix(style="border-bottom: none")
+      .clearfix(style="margin-bottom: 10px")
         .page-header-buttons
           - if perms.msgs.label_update or org_perms.msgs.label_update
             .btn-group
-              %button.btn.btn-default{ type:"button", ng-if:"!label.watching", ng-click:"onWatch()" }
+              %button.btn.btn-default(type="button" ng-if="!label.watching" ng-click="onWatch()")
                 %i.glyphicon.glyphicon-eye-open
                 - trans "Watch"
-              %button.btn.btn-default{ type:"button", ng-if:"label.watching", ng-click:"onUnwatch()" }
+              %button.btn.btn-default(type="button" ng-if="label.watching" ng-click="onUnwatch()")
                 %i.glyphicon.glyphicon-eye-close
                 - trans "Unwatch"
-              %a.btn.btn-default{ href:"{% url 'msgs.label_update' object.pk %}", tooltip:"Edit Label" }
+              %a.btn.btn-default(href="{% url 'msgs.label_update' object.pk %}" tooltip="Edit Label")
                 %i.glyphicon.glyphicon-pencil
               - if perms.msgs.label_delete or org_perms.msgs.label_delete
-                %a.btn.btn-default{ ng-click:"onDeleteLabel()", tooltip:"Delete" }
+                %a.btn.btn-default(ng-click="onDeleteLabel()" tooltip="Delete")
                   %i.glyphicon.glyphicon-trash
 
         %h2
@@ -32,9 +32,9 @@
         .
           [[ label.description ]]
 
-    %uib-tabset{ active: "active" }
+    %uib-tabset(active="active")
 
-      %uib-tab{ index:"0", select:"onTabSelect(0)" }
+      %uib-tab(index="0" select="onTabSelect(0)")
         %uib-tab-heading
           %i.glyphicon.glyphicon-dashboard
           - trans "Summary"
@@ -46,6 +46,9 @@
                 Inbox messages: <strong>[[ label.counts.inbox | number ]]</strong>
               %li
                 Archived messages: <strong>[[ label.counts.archived | number ]]</strong>
+              - if object.rule
+                %li
+                  Applied when {{ object.rule|render_tests }}
           .col-md-8
             #chart-incoming-by-day
 


### PR DESCRIPTION
Now that we allow labelling rules without keywords, important that users can see what rules they have created.

<img width="680" alt="Captura de Pantalla 2019-12-19 a la(s) 12 26 53" src="https://user-images.githubusercontent.com/675558/71194919-ddb13280-225a-11ea-8c4b-6253c02aab9b.png">
