### PR TITLE
If case is assigned to specific user, only notify that user

### DIFF
--- a/casepro/cases/models.py
+++ b/casepro/cases/models.py
@@ -281,10 +281,10 @@ class Case(models.Model):
             case = cls.objects.create(
                 org=org,
                 assignee=assignee,
+                user_assignee=user_assignee,
                 initial_message=message,
                 contact=contact,
                 summary=summary,
-                user_assignee=user_assignee,
             )
 
             if message:
@@ -297,9 +297,11 @@ class Case(models.Model):
             case.watchers.add(user)
             action = CaseAction.create(case, user, CaseAction.OPEN, assignee=assignee, user_assignee=user_assignee)
 
-            for assignee_user in assignee.get_users():
-                if assignee_user != user:
-                    Notification.new_case_assignment(org, assignee_user, action)
+            notify_users = [user_assignee] if user_assignee else assignee.get_users()
+            for notify_user in notify_users:
+                if notify_user != user:
+                    Notification.new_case_assignment(org, notify_user, action)
+
         return case
 
     def get_timeline(self, after, before, merge_from_backend):

--- a/casepro/cases/tests.py
+++ b/casepro/cases/tests.py
@@ -366,7 +366,7 @@ class CaseTest(BaseCasesTest):
         open_case = Case.get_open_for_contact_on(self.unicef, self.ann, datetime(2014, 1, 16, 0, 0, tzinfo=pytz.UTC))
         self.assertEqual(open_case, case2)
 
-    def test_get_open_with_user_assignee(self):
+    def test_get_or_open_with_user_assignee(self):
         """
         If a case is opened with the user_assignee field set, the created case should have the assigned user, and
         the created case action should also have the assigned user.
@@ -380,6 +380,10 @@ class CaseTest(BaseCasesTest):
 
         case_action = CaseAction.objects.get(case=case)
         self.assertEqual(case_action.user_assignee, self.user1)
+
+        # only assigned user should be notified
+        self.assertEqual(Notification.objects.count(), 1)
+        Notification.objects.get(user=self.user1, type=Notification.TYPE_CASE_ASSIGNMENT)
 
     def test_get_open_no_initial_message_new_case(self):
         """


### PR DESCRIPTION
Instead of the entire partner org