### PR TITLE
Fix 0015_populate_is_squashed migration in statistics app

### DIFF
--- a/casepro/statistics/migrations/0015_populate_is_squashed.py
+++ b/casepro/statistics/migrations/0015_populate_is_squashed.py
@@ -31,7 +31,7 @@ def populate_for_model(model):
         max_id = id_batch[-1]
         num_updated += len(id_batch)
 
-        print(f" > Updated {num_updated} instances of {model.name}")
+        print(f" > Updated {num_updated} instances of {model._meta.object_name}")
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Get name of django model using `Model._meta.object_name` instead of
`Model.name`. Using `Model.name` raises an `AttributeError`