### PR TITLE
Add push contacts for rapidpro

### DIFF
--- a/casepro/backend/__init__.py
+++ b/casepro/backend/__init__.py
@@ -97,7 +97,7 @@ class BaseBackend(object):
         """
 
     @abstractmethod
-    def push_contact(self, org, contact):
+    def resolve_urn(self, org, contact):
         """
         Pushes a new contact
 

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -332,11 +332,11 @@ class RapidProBackend(BaseBackend):
                 msg.backend_broadcast_id = broadcast.id
                 msg.save(update_fields=("backend_broadcast_id",))
 
-    def push_contact(self, org, normalised_urn):
+    def resolve_urn(self, org, normalized_urn):
         client = self._get_client(org)
-        contact = client.get_contacts(urn=f"{normalised_urn}")
+        contact = client.get_contacts(urn=normalized_urn)
         if not contact.first():
-            contact = client.create_contact(urns=[normalised_urn])
+            contact = client.create_contact(urns=[normalized_urn])
         else:
             contact = contact.first()
         return contact.uuid

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -335,7 +335,7 @@ class RapidProBackend(BaseBackend):
     def push_contact(self, org, normalised_urn):
         client = self._get_client(org)
         contact = client.get_contacts(urn=f"{normalised_urn}")
-        if not contact:
+        if not contact.all():
             contact = client.create_contact(urns=[normalised_urn])
         return contact.uuid
 

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -45,6 +45,7 @@ class ContactSyncer(BaseSyncer):
             "uuid": remote.uuid,
             "name": remote.name,
             "language": remote.language,
+            "urns": remote.urns,
             "is_blocked": remote.blocked,
             "is_stopped": remote.stopped,
             "is_stub": False,
@@ -59,6 +60,7 @@ class ContactSyncer(BaseSyncer):
             or local.language != remote.language
             or local.is_blocked != remote.blocked
             or local.is_stopped != remote.stopped
+            or local.urns != remote.urns
         ):
             return True
 
@@ -330,8 +332,11 @@ class RapidProBackend(BaseBackend):
                 msg.backend_broadcast_id = broadcast.id
                 msg.save(update_fields=("backend_broadcast_id",))
 
-    def push_contact(self, org, contact):
-        return
+    def push_contact(self, org, normalised_urn):
+        client = self._get_client(org)
+        client.create_contact(urns=[normalised_urn])
+        contact = client.get_contacts(urn=f"{normalised_urn}").first()
+        return contact.uuid
 
     def add_to_group(self, org, contact, group):
         client = self._get_client(org)

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -334,8 +334,9 @@ class RapidProBackend(BaseBackend):
 
     def push_contact(self, org, normalised_urn):
         client = self._get_client(org)
-        client.create_contact(urns=[normalised_urn])
-        contact = client.get_contacts(urn=f"{normalised_urn}").first()
+        contact = client.get_contacts(urn=f"{normalised_urn}")
+        if not contact:
+            contact = client.create_contact(urns=[normalised_urn])
         return contact.uuid
 
     def add_to_group(self, org, contact, group):

--- a/casepro/backend/rapidpro.py
+++ b/casepro/backend/rapidpro.py
@@ -335,8 +335,10 @@ class RapidProBackend(BaseBackend):
     def push_contact(self, org, normalised_urn):
         client = self._get_client(org)
         contact = client.get_contacts(urn=f"{normalised_urn}")
-        if not contact.all():
+        if not contact.first():
             contact = client.create_contact(urns=[normalised_urn])
+        else:
+            contact = contact.first()
         return contact.uuid
 
     def add_to_group(self, org, contact, group):

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -885,7 +885,7 @@ class RapidProBackendTest(BaseCasesTest):
         self.assertNotCalled(mock_create_contact)
 
         # Contact doesn't exist in RapidPro
-        mock_get_contacts.return_value = None
+        mock_get_contacts.return_value = MockClientQuery([])
         mock_create_contact.return_value = TembaContact.create(uuid="1")
 
         self.ann.urns = ["tel:+1234"]

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -868,19 +868,32 @@ class RapidProBackendTest(BaseCasesTest):
 
     @patch("dash.orgs.models.TembaClient.get_contacts")
     @patch("dash.orgs.models.TembaClient.create_contact")
-    def test_push_contact(self, mock_get_contacts, mock_create_contact):
+    def test_push_contact(self, mock_create_contact, mock_get_contacts):
         """
         If a contact is added in CasePro,
         it should be added in RapidPro and the uuid should match
         """
         # Contact does not exist, so push contacts is called
-        mock_get_contacts.return_value = MockClientQuery([TembaContact.create(uuid="1")])
-        mock_create_contact.return_value = MockClientQuery([TembaContact.create(uuid="1")])
-        self.ann.urns = ["tel:1234"]
+        mock_get_contacts.return_value = TembaContact.create(uuid="1", urns=['tel:1234'])
+        mock_create_contact.return_value = None
+
+        self.ann.urns = ["tel:+1234"]
         self.ann.save()
         self.backend.push_contact(self.unicef, self.ann.urns[0])
-        mock_get_contacts.assert_called_with(urns=["tel:1234"])
-        mock_create_contact.assert_called_with(urn="tel:1234")
+
+        mock_get_contacts.assert_called_once_with(urn="tel:+1234")
+        self.assertNotCalled(mock_create_contact)
+
+        # contact doesn't exist in RapidPro
+        mock_get_contacts.return_value = None
+        mock_create_contact.return_value = TembaContact.create(uuid="1")
+
+        self.ann.urns = ["tel:+1234"]
+        self.ann.save()
+        self.backend.push_contact(self.unicef, self.ann.urns[0])
+
+        mock_get_contacts.assert_called_with(urn="tel:+1234")
+        mock_create_contact.assert_called_once_with(urns=['tel:+1234'])
 
     @patch("dash.orgs.models.TembaClient.bulk_add_contacts")
     def test_add_to_group(self, mock_add_contacts):

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -873,16 +873,14 @@ class RapidProBackendTest(BaseCasesTest):
         If a contact is added in CasePro,
         it should be added in RapidPro and the uuid should match
         """
-        # self.ann.uuid = None
-        # self.ann.urns = ["tel:1234"]
-        # self.ann.save()
-        # self.backend.push_contact(self.unicef, self.ann.urns[0])
-        # I dont know what to assert here lol
-        self.bob.refresh_from_db()
-        old_bob = self.bob.__dict__.copy()
-        self.backend.push_contact(self.unicef, self.bob)
-        self.bob.refresh_from_db()
-        self.assertEqual(self.bob.__dict__, old_bob)
+        # Contact does not exist, so push contacts is called
+        mock_get_contacts.return_value = MockClientQuery([TembaContact.create(uuid="1")])
+        mock_create_contact.return_value = MockClientQuery([TembaContact.create(uuid="1")])
+        self.ann.urns = ["tel:1234"]
+        self.ann.save()
+        self.backend.push_contact(self.unicef, self.ann.urns[0])
+        mock_get_contacts.assert_called_with(urns=["tel:1234"])
+        mock_create_contact.assert_called_with(urn="tel:1234")
 
     @patch("dash.orgs.models.TembaClient.bulk_add_contacts")
     def test_add_to_group(self, mock_add_contacts):

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -874,7 +874,9 @@ class RapidProBackendTest(BaseCasesTest):
         it must be added
         """
         # Contact does exist in RapidPro
-        mock_get_contacts.return_value = TembaContact.create(uuid="1", urns=["tel:1234"])
+        mock_get_contacts.return_value = MockClientQuery(
+            [TembaContact.create(uuid="1", urns=["tel:1234"])]
+        )
         mock_create_contact.return_value = None
 
         self.ann.urns = ["tel:+1234"]

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -112,6 +112,27 @@ class ContactSyncerTest(BaseCasesTest):
             )
         )
 
+        local.urns = ["tel:1234"]
+
+        # no differences (besides null field value which is ignored)
+        self.assertFalse(
+            self.syncer.update_required(
+                local,
+                TembaContact.create(
+                    uuid="000-001",
+                    name="Ann",
+                    urns=["tel:1234"],
+                    groups=[ObjectRef.create(uuid="G-003", name="Reporters")],
+                    fields={"chat_name": "ann", "age": None},
+                    language="eng",
+                    blocked=False,
+                    stopped=False,
+                    modified_on=now(),
+                ),
+                {},
+            )
+        )
+
         # name change
         self.assertTrue(
             self.syncer.update_required(

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -874,9 +874,7 @@ class RapidProBackendTest(BaseCasesTest):
         it must be added
         """
         # Contact does exist in RapidPro
-        mock_get_contacts.return_value = MockClientQuery(
-            [TembaContact.create(uuid="1", urns=["tel:1234"])]
-        )
+        mock_get_contacts.return_value = MockClientQuery([TembaContact.create(uuid="1", urns=["tel:1234"])])
         mock_create_contact.return_value = None
 
         self.ann.urns = ["tel:+1234"]

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -874,7 +874,7 @@ class RapidProBackendTest(BaseCasesTest):
         it should be added in RapidPro and the uuid should match
         """
         # Contact does not exist, so push contacts is called
-        mock_get_contacts.return_value = TembaContact.create(uuid="1", urns=['tel:1234'])
+        mock_get_contacts.return_value = TembaContact.create(uuid="1", urns=["tel:1234"])
         mock_create_contact.return_value = None
 
         self.ann.urns = ["tel:+1234"]
@@ -893,7 +893,7 @@ class RapidProBackendTest(BaseCasesTest):
         self.backend.push_contact(self.unicef, self.ann.urns[0])
 
         mock_get_contacts.assert_called_with(urn="tel:+1234")
-        mock_create_contact.assert_called_once_with(urns=['tel:+1234'])
+        mock_create_contact.assert_called_once_with(urns=["tel:+1234"])
 
     @patch("dash.orgs.models.TembaClient.bulk_add_contacts")
     def test_add_to_group(self, mock_add_contacts):

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -870,10 +870,10 @@ class RapidProBackendTest(BaseCasesTest):
     @patch("dash.orgs.models.TembaClient.create_contact")
     def test_push_contact(self, mock_create_contact, mock_get_contacts):
         """
-        If a contact is added in CasePro,
-        it should be added in RapidPro and the uuid should match
+        If a contact is added in CasePro if the contact doesnt exist in RapidPro,
+        it must be added
         """
-        # Contact does not exist, so push contacts is called
+        # Contact does exist in RapidPro
         mock_get_contacts.return_value = TembaContact.create(uuid="1", urns=["tel:1234"])
         mock_create_contact.return_value = None
 
@@ -884,7 +884,7 @@ class RapidProBackendTest(BaseCasesTest):
         mock_get_contacts.assert_called_once_with(urn="tel:+1234")
         self.assertNotCalled(mock_create_contact)
 
-        # contact doesn't exist in RapidPro
+        # Contact doesn't exist in RapidPro
         mock_get_contacts.return_value = None
         mock_create_contact.return_value = TembaContact.create(uuid="1")
 

--- a/casepro/backend/tests/test_rapidpro.py
+++ b/casepro/backend/tests/test_rapidpro.py
@@ -868,7 +868,7 @@ class RapidProBackendTest(BaseCasesTest):
 
     @patch("dash.orgs.models.TembaClient.get_contacts")
     @patch("dash.orgs.models.TembaClient.create_contact")
-    def test_push_contact(self, mock_create_contact, mock_get_contacts):
+    def test_resolve_urn(self, mock_create_contact, mock_get_contacts):
         """
         If a contact is added in CasePro if the contact doesnt exist in RapidPro,
         it must be added
@@ -879,7 +879,7 @@ class RapidProBackendTest(BaseCasesTest):
 
         self.ann.urns = ["tel:+1234"]
         self.ann.save()
-        self.backend.push_contact(self.unicef, self.ann.urns[0])
+        self.backend.resolve_urn(self.unicef, self.ann.urns[0])
 
         mock_get_contacts.assert_called_once_with(urn="tel:+1234")
         self.assertNotCalled(mock_create_contact)
@@ -890,7 +890,7 @@ class RapidProBackendTest(BaseCasesTest):
 
         self.ann.urns = ["tel:+1234"]
         self.ann.save()
-        self.backend.push_contact(self.unicef, self.ann.urns[0])
+        self.backend.resolve_urn(self.unicef, self.ann.urns[0])
 
         mock_get_contacts.assert_called_with(urn="tel:+1234")
         mock_create_contact.assert_called_once_with(urns=["tel:+1234"])

--- a/casepro/cases/views.py
+++ b/casepro/cases/views.py
@@ -109,7 +109,7 @@ class CaseCRUDL(SmartCRUDL):
             context["can_update"] = can_update
             context["alert"] = self.request.GET.get("alert", None)
             context["case_id"] = case.id
-
+            context["site_redact_urns"] = getattr(settings, "SITE_REDACT_URNS", True)
             return context
 
     class Open(OrgPermsMixin, SmartCreateView):

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -321,13 +321,11 @@ class Contact(models.Model):
         contact = cls.objects.filter(urns__contains=[normalized_urn]).first()
         if not contact:
             URN.validate(normalized_urn)
-            uuid = org.get_backend().push_contact(org, normalized_urn)
+            uuid = org.get_backend().resolve_urn(org, normalized_urn)
             contact = cls.objects.filter(uuid=uuid)
 
             if not contact:
-                contact = cls.objects.create(org=org, name=name, urns=[normalized_urn], is_stub=False)
-                contact.uuid = uuid
-                contact.save()
+                contact = cls.objects.create(org=org, name=name, urns=[normalized_urn], is_stub=False, uuid=uuid)
         return contact
 
     @classmethod

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -324,6 +324,7 @@ class Contact(models.Model):
             uuid = org.get_backend().push_contact(org, normalized_urn)
             contact = cls.objects.create(org=org, name=name, urns=[normalized_urn], is_stub=False)
             contact.uuid = uuid
+            contact.save()
         return contact
 
     @classmethod

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -33,8 +33,9 @@ class URN(object):
     SCHEME_TEL = "tel"
     SCHEME_TWITTER = "twitter"
     SCHEME_EMAIL = "mailto"
+    SCHEME_WHATSAPP = "whatsapp"
 
-    VALID_SCHEMES = (SCHEME_TEL, SCHEME_TWITTER, SCHEME_EMAIL)
+    VALID_SCHEMES = (SCHEME_TEL, SCHEME_TWITTER, SCHEME_EMAIL, SCHEME_WHATSAPP)
 
     def __init__(self):  # pragma: no cover
         raise ValueError("Class shouldn't be instantiated")
@@ -79,7 +80,7 @@ class URN(object):
 
         norm_path = str(path).strip()
 
-        if scheme == cls.SCHEME_TEL:
+        if scheme == cls.SCHEME_TEL or scheme == cls.SCHEME_WHATSAPP:
             norm_path = cls.normalize_phone(norm_path)
         elif scheme == cls.SCHEME_TWITTER:
             norm_path = norm_path.lower()

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -317,13 +317,12 @@ class Contact(models.Model):
         Gets an existing contact or creates a new contact. Used when opening a case without an initial message
         """
         normalized_urn = URN.normalize(urn)
-
         contact = cls.objects.filter(urns__contains=[normalized_urn]).first()
         if not contact:
             URN.validate(normalized_urn)
-
+            uuid = org.get_backend().push_contact(org, normalized_urn)
             contact = cls.objects.create(org=org, name=name, urns=[normalized_urn], is_stub=False)
-            org.get_backend().push_contact(org, contact)
+            contact.uuid = uuid
         return contact
 
     @classmethod

--- a/casepro/contacts/models.py
+++ b/casepro/contacts/models.py
@@ -322,9 +322,12 @@ class Contact(models.Model):
         if not contact:
             URN.validate(normalized_urn)
             uuid = org.get_backend().push_contact(org, normalized_urn)
-            contact = cls.objects.create(org=org, name=name, urns=[normalized_urn], is_stub=False)
-            contact.uuid = uuid
-            contact.save()
+            contact = cls.objects.filter(uuid=uuid)
+
+            if not contact:
+                contact = cls.objects.create(org=org, name=name, urns=[normalized_urn], is_stub=False)
+                contact.uuid = uuid
+                contact.save()
         return contact
 
     @classmethod

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -213,12 +213,12 @@ class ContactTest(BaseCasesTest):
         """
         Contact.objects.all().delete()
 
-        # try with a URN that doesn't match an existing contact
+        # try with a URN that doesn't match an existing contact, uuid set from backend
         contact1 = Contact.get_or_create_from_urn(self.unicef, "tel:+27827654321")
 
         self.assertEqual(contact1.urns, ["tel:+27827654321"])
         self.assertIsNone(contact1.name)
-        self.assertIsNone(contact1.uuid)
+        self.assertIsNotNone(contact1.uuid)
 
         # check that the backend was updated
         self.assertTrue(mock_push_contact.called)

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -211,6 +211,7 @@ class ContactTest(BaseCasesTest):
         """
         If no contact with a matching urn exists a new one should be created
         """
+        mock_push_contact.return_value = "00001"
         Contact.objects.all().delete()
 
         # try with a URN that doesn't match an existing contact, uuid set from backend

--- a/casepro/contacts/tests.py
+++ b/casepro/contacts/tests.py
@@ -206,12 +206,12 @@ class ContactTest(BaseCasesTest):
                 },
             )
 
-    @patch("casepro.test.TestBackend.push_contact")
-    def test_get_or_create_from_urn(self, mock_push_contact):
+    @patch("casepro.test.TestBackend.resolve_urn")
+    def test_get_or_create_from_urn(self, mock_resolve_urn):
         """
         If no contact with a matching urn exists a new one should be created
         """
-        mock_push_contact.return_value = "00001"
+        mock_resolve_urn.return_value = "00001"
         Contact.objects.all().delete()
 
         # try with a URN that doesn't match an existing contact, uuid set from backend
@@ -222,22 +222,22 @@ class ContactTest(BaseCasesTest):
         self.assertIsNotNone(contact1.uuid)
 
         # check that the backend was updated
-        self.assertTrue(mock_push_contact.called)
-        mock_push_contact.reset_mock()
+        self.assertTrue(mock_resolve_urn.called)
+        mock_resolve_urn.reset_mock()
 
         # try with a URN that does match an existing contact
         contact2 = Contact.get_or_create_from_urn(self.unicef, "tel:+27827654321")
         self.assertEqual(contact2, contact1)
 
         # we shouldn't update the backend because a contact wasn't created
-        self.assertFalse(mock_push_contact.called)
+        self.assertFalse(mock_resolve_urn.called)
 
         # URN will be normalized
         contact3 = Contact.get_or_create_from_urn(self.unicef, "tel:+(278)-2765-4321")
         self.assertEqual(contact3, contact1)
 
         # we shouldn't update the backend because a contact wasn't created
-        self.assertFalse(mock_push_contact.called)
+        self.assertFalse(mock_resolve_urn.called)
 
         # we get an exception if URN isn't valid (e.g. local number)
         self.assertRaises(InvalidURN, Contact.get_or_create_from_urn, self.unicef, "tel:0827654321")

--- a/casepro/contacts/views.py
+++ b/casepro/contacts/views.py
@@ -36,6 +36,7 @@ class ContactCRUDL(SmartCRUDL):
                 "contact": self.object.as_json(full=True),
                 "fields": [f.as_json() for f in fields],
             }
+            context["site_redact_urns"] = getattr(settings, "SITE_REDACT_URNS", True)
             context["backend_url"] = settings.SITE_EXTERNAL_CONTACT_URL % self.object.uuid
             return context
 

--- a/casepro/settings_common.py
+++ b/casepro/settings_common.py
@@ -68,6 +68,7 @@ SITE_EXTERNAL_CONTACT_URL = "http://localhost:8001/contact/read/%s/"
 SITE_BACKEND = "casepro.backend.NoopBackend"
 SITE_HIDE_CONTACT_FIELDS = []  # Listed fields should not be displayed
 SITE_CONTACT_DISPLAY = "name"  # Overrules SITE_HIDE_CONTACT_FIELDS Options: 'name', 'uuid' or 'urns'
+SITE_REDACT_URNS = True
 SITE_ALLOW_CASE_WITHOUT_MESSAGE = True
 SITE_MAX_MESSAGE_CHARS = 160  # the max value for this is 800
 

--- a/static/coffee/utils.coffee
+++ b/static/coffee/utils.coffee
@@ -52,7 +52,7 @@ namespace('utils', (exports) ->
       rejectFn(v)
 
   exports.formatUrns = (urns) ->
-    scheme_names = {'tel': "Phone", 'mailto': "Email", 'twitter': "Twitter"}
+    scheme_names = {'tel': "Phone", 'mailto': "Email", 'twitter': "Twitter", 'whatsapp': "WhatsApp"}
     formatted_urns = []
     for urn in urns
       urn_parts = urn.split(':')

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -169,7 +169,10 @@
                 .contact-field-label.col-sm-6
                   [[ urn.scheme ]]
                 .contact-field-value.col-sm-6
-                  [[ ]]
+                  - if site_redact_urns
+                    [[ "\u2022".repeat(urn.path.length) ]]
+                  - else
+                    [[ urn.path ]]
               .row{ ng-if:"contact.language" }
                 .contact-field-label.col-sm-6
                   - trans "Language"

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -170,7 +170,7 @@
                   [[ urn.scheme ]]
                 .contact-field-value.col-sm-6
                   - if site_redact_urns
-                    [[ "\u2022".repeat(urn.path.length) ]]
+                    [[ "\u2022".repeat(8) ]]
                   - else
                     [[ urn.path ]]
               .row{ ng-if:"contact.language" }

--- a/templates/cases/case_read.haml
+++ b/templates/cases/case_read.haml
@@ -169,7 +169,7 @@
                 .contact-field-label.col-sm-6
                   [[ urn.scheme ]]
                 .contact-field-value.col-sm-6
-                  [[ urn.path ]]
+                  [[ ]]
               .row{ ng-if:"contact.language" }
                 .contact-field-label.col-sm-6
                   - trans "Language"

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -69,7 +69,7 @@
                 .contact-field-label.col-sm-6
                   [[ urn.scheme ]]
                 .contact-field-value.col-sm-6
-                  [[ urn.path ]]
+                  [[  ]]
               .row
                 .contact-field-label.col-sm-6
                   - trans "Language"

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -69,7 +69,10 @@
                 .contact-field-label.col-sm-6
                   [[ urn.scheme ]]
                 .contact-field-value.col-sm-6
-                  [[  ]]
+                  - if site_redact_urns
+                    [[ "\u2022".repeat(urn.path.length) ]]
+                  - else
+                    [[ urn.path ]]
               .row
                 .contact-field-label.col-sm-6
                   - trans "Language"

--- a/templates/contacts/contact_read.haml
+++ b/templates/contacts/contact_read.haml
@@ -70,7 +70,7 @@
                   [[ urn.scheme ]]
                 .contact-field-value.col-sm-6
                   - if site_redact_urns
-                    [[ "\u2022".repeat(urn.path.length) ]]
+                    [[ "\u2022".repeat(8) ]]
                   - else
                     [[ urn.path ]]
               .row


### PR DESCRIPTION
The `push_contact` functionality was necessary for the Open Case button functionality. For this to work a few things are necessary, as summarised below:
- URNs need to be synced to CasePro to check if the URN already exists in both CasePro and RapidPro.
- URNs also needed to be hidden from the UI for privacy. I removed the `urn.path` from the frontend but left the placeholder.
- `push_contact` checks for the contact in RapidPro by the URN, if it doesn't exist, the contact is created in RapidPro and the RapidPro `uuid` is returned.
- `get_or_create_from_urn` looks for the contact in CasePro by the URN, if it does not exist, it gets the contact from RapidPro and its `uuid`, it then looks for the CasePro contact by the `uuid` to avoid duplicated, if it still doesn't exist, a new CasePro contact is made and the `uuid` is set to match the RapidPro `uuid`.
- As we make use of WhatsApp, the WhatsApp scheme is also added as a valid scheme. 
- The test were also updated to accommodate the new functionality.